### PR TITLE
chore: sync template from tschm/.config-templates@main

### DIFF
--- a/.github/workflows/deptry.yml
+++ b/.github/workflows/deptry.yml
@@ -26,7 +26,7 @@ jobs:
     name: Check dependencies with deptry
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/astral-sh/uv:0.9.6-python3.12-trixie
+      image: ghcr.io/astral-sh/uv:0.9.7-python3.12-trixie
 
     steps:
       - uses: actions/checkout@v5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.14.2'
+    rev: 'v0.14.3'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -60,6 +60,12 @@ exclude = ["**/[{][{]*/", "**/*[}][}]*/"]
 # UP: pyupgrade - Upgrade syntax for newer Python
 select = ["D", "E", "F", "I", "N", "W", "UP"]
 
+# Ensure docstrings are required for magic methods (e.g., __init__) and
+# private/underscored modules by explicitly selecting the relevant pydocstyle
+# rules in addition to the D set. This makes the intent clear and future-proof
+# if the default pydocstyle selection changes.
+extend-select = ["D105", "D107"]
+
 # Resolve incompatible pydocstyle rules: prefer D211 and D212 over D203 and D213
 ignore = ["D203", "D213"]
 


### PR DESCRIPTION
This PR updates configuration files from
[tschm/.config-templates@main](https://github.com/tschm/.config-templates/tree/main).