### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -3,7 +3,14 @@ repo: jebel-quant/rhiza
 host: github
 ref: v0.9.5
 include: []
-exclude: []
+exclude:
+- .rhiza/docs
+- .rhiza/make.d/agentic.mk
+- .rhiza/make.d/custom-env.mk
+- .rhiza/make.d/custom-task.mk
+- .rhiza/make.d/gh-aw.mk
+- .rhiza/make.d/README.md
+- .rhiza/tests/api/test_gh_aw_targets.py
 templates:
 - github
 - legal
@@ -44,20 +51,8 @@ files:
 - .rhiza/CODE_OF_CONDUCT.md
 - .rhiza/CONTRIBUTING.md
 - .rhiza/assets/rhiza-logo.svg
-- .rhiza/docs/ASSETS.md
-- .rhiza/docs/CONFIG.md
-- .rhiza/docs/LFS.md
-- .rhiza/docs/PRIVATE_PACKAGES.md
-- .rhiza/docs/RELEASING.md
-- .rhiza/docs/TOKEN_SETUP.md
-- .rhiza/docs/WORKFLOWS.md
-- .rhiza/make.d/README.md
-- .rhiza/make.d/agentic.mk
 - .rhiza/make.d/book.mk
 - .rhiza/make.d/bootstrap.mk
-- .rhiza/make.d/custom-env.mk
-- .rhiza/make.d/custom-task.mk
-- .rhiza/make.d/gh-aw.mk
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
 - .rhiza/make.d/quality.mk
@@ -71,7 +66,6 @@ files:
 - .rhiza/rhiza.mk
 - .rhiza/tests/README.md
 - .rhiza/tests/api/conftest.py
-- .rhiza/tests/api/test_gh_aw_targets.py
 - .rhiza/tests/api/test_github_targets.py
 - .rhiza/tests/api/test_makefile_api.py
 - .rhiza/tests/api/test_makefile_targets.py
@@ -112,5 +106,5 @@ files:
 - pytest.ini
 - renovate.json
 - ruff.toml
-synced_at: '2026-04-13T19:42:11Z'
+synced_at: '2026-04-20T01:14:38Z'
 strategy: merge

--- a/.rhiza/tests/integration/test_docs_targets.py
+++ b/.rhiza/tests/integration/test_docs_targets.py
@@ -1,0 +1,69 @@
+"""Tests for book.mk Makefile targets and the MKDOCS_EXTRA_PACKAGES variable."""
+
+import shutil
+import subprocess  # nosec
+
+import pytest
+
+MAKE = shutil.which("make") or "/usr/bin/make"
+
+
+@pytest.fixture
+def book_makefile(git_repo):
+    """Return the book.mk path or skip tests if missing."""
+    makefile = git_repo / ".rhiza" / "make.d" / "book.mk"
+    if not makefile.exists():
+        pytest.skip("book.mk not found, skipping test")
+    return makefile
+
+
+def test_mkdocs_extra_packages_variable_defined(book_makefile):
+    """Test that MKDOCS_EXTRA_PACKAGES is declared with a default-empty value."""
+    content = book_makefile.read_text()
+    assert "MKDOCS_EXTRA_PACKAGES ?=" in content, "book.mk should declare MKDOCS_EXTRA_PACKAGES with a ?= default"
+
+
+def test_mkdocs_extra_packages_used_in_build(book_makefile):
+    """Test that MKDOCS_EXTRA_PACKAGES is spliced into the mkdocs build uvx command."""
+    content = book_makefile.read_text()
+    # The variable must appear on the same line as 'mkdocs build'
+    build_lines = [line for line in content.splitlines() if "mkdocs build" in line]
+    assert build_lines, "book.mk should contain a 'mkdocs build' invocation"
+    assert any("$(MKDOCS_EXTRA_PACKAGES)" in line for line in build_lines), (
+        "mkdocs build line should include $(MKDOCS_EXTRA_PACKAGES)"
+    )
+
+
+def test_mkdocs_extra_packages_used_in_serve(book_makefile):
+    """Test that MKDOCS_EXTRA_PACKAGES is spliced into the mkdocs-serve uvx command."""
+    content = book_makefile.read_text()
+    serve_lines = [line for line in content.splitlines() if "mkdocs serve" in line]
+    assert serve_lines, "book.mk should contain a 'mkdocs serve' invocation"
+    assert any("$(MKDOCS_EXTRA_PACKAGES)" in line for line in serve_lines), (
+        "mkdocs serve line should include $(MKDOCS_EXTRA_PACKAGES)"
+    )
+
+
+def test_mkdocs_build_dry_run_with_extra_packages(git_repo, book_makefile):
+    """Test that passing MKDOCS_EXTRA_PACKAGES on the command line is accepted by make.
+
+    Validates both a single package and multiple packages to confirm the variable
+    correctly extends the uvx invocation in all cases.
+    """
+    for extra in [
+        "--with mkdocs-graphviz",
+        "--with mkdocs-graphviz --with mkdocs-mermaid2",
+    ]:
+        result = subprocess.run(  # nosec
+            [MAKE, "-n", "book", f"MKDOCS_EXTRA_PACKAGES={extra}"],
+            cwd=git_repo,
+            capture_output=True,
+            text=True,
+        )
+        assert "no rule to make target" not in result.stderr.lower(), "book should be a defined target"
+        assert result.returncode == 0, f"Dry-run failed: {result.stderr}"
+        # Each extra package flag should appear in the dry-run output
+        for pkg in ["mkdocs-graphviz", "mkdocs-mermaid2"][: len(extra.split("--with")) - 1]:
+            assert pkg in result.stdout, (
+                f"MKDOCS_EXTRA_PACKAGES package '{pkg}' should be visible in the dry-run command"
+            )

--- a/docs/adr/0000-adr-template.md
+++ b/docs/adr/0000-adr-template.md
@@ -1,0 +1,19 @@
+# [NUMBER]. [TITLE]
+
+Date: [YYYY-MM-DD]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by [ADR-XXXX](XXXX-title.md)]
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **2** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Documentation

<details>
<summary>Added (1)</summary>

- ✅ `docs/adr/0000-adr-template.md`

</details>

#### Rhiza Configuration

<details>
<summary>Added (1)</summary>

- ✅ `.rhiza/tests/integration/test_docs_targets.py`

</details>

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@main`
- Last sync: 2026-04-15T00:03:53+04:00
- Sync date: 2026-04-20T01:14:39.796331+00:00