### PR TITLE
chore: sync rhiza template to v0.10.5

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -95,5 +95,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-05-15T13:36:15Z'
+synced_at: '2026-05-17T09:16:35Z'
 strategy: merge


### PR DESCRIPTION
## Summary

- Re-runs `make sync` against the rhiza template at `ref: v0.10.5`
- Template content was already up to date (`sha: 1c6bd1d29660`) — no file changes
- Updates `synced_at` timestamp in `.rhiza/template.lock`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)