### PR TITLE
fix: CAGR sign flip in reports, accept integer rf, harden API endpoint

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,12 +1,38 @@
 """FastAPI web application for jquantstats portfolio analysis."""
 
 import polars as pl
-from fastapi import FastAPI, UploadFile
+from fastapi import FastAPI, Form, HTTPException, UploadFile
 from fastapi.responses import HTMLResponse
 
 from jquantstats import Portfolio
 
 app = FastAPI(title="jquantstats API")
+
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MiB per CSV upload
+
+
+async def _read_csv(upload: UploadFile) -> pl.DataFrame:
+    """Read an uploaded CSV into a DataFrame, rejecting oversized or invalid files.
+
+    Args:
+        upload: The uploaded file to parse.
+
+    Returns:
+        pl.DataFrame: The parsed CSV content.
+
+    Raises:
+        HTTPException: 413 if the file exceeds ``MAX_UPLOAD_BYTES``,
+            400 if the content is not valid CSV.
+
+    """
+    raw = await upload.read()
+    if len(raw) > MAX_UPLOAD_BYTES:
+        limit_mib = MAX_UPLOAD_BYTES // (1024 * 1024)
+        raise HTTPException(status_code=413, detail=f"{upload.filename}: file exceeds {limit_mib} MiB limit")
+    try:
+        return pl.read_csv(raw)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"{upload.filename}: invalid CSV ({exc})") from exc
 
 
 @app.get("/")
@@ -16,13 +42,22 @@ def root() -> dict:
 
 
 @app.post("/report", response_class=HTMLResponse)
-async def generate_report(prices: UploadFile, positions: UploadFile) -> str:
+async def generate_report(
+    prices: UploadFile,
+    positions: UploadFile,
+    aum: float = Form(default=1_000_000, gt=0),
+) -> str:
     """Accept prices and positions CSVs and return a full HTML analytics report."""
-    prices_df = pl.read_csv(await prices.read())
-    positions_df = pl.read_csv(await positions.read())
-    pf = Portfolio.from_cash_position(
-        prices=prices_df,
-        cash_position=positions_df,
-        aum=1_000_000,
-    )
-    return pf.report.to_html()
+    prices_df = await _read_csv(prices)
+    positions_df = await _read_csv(positions)
+    try:
+        pf = Portfolio.from_cash_position(
+            prices=prices_df,
+            cash_position=positions_df,
+            aum=aum,
+        )
+        return pf.report.to_html()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"failed to build report: {exc}") from exc

--- a/src/jquantstats/_reports/_data.py
+++ b/src/jquantstats/_reports/_data.py
@@ -60,7 +60,7 @@ def _cagr_since(
             continue
         total = float((1.0 + s).product()) - 1.0
         years = n / periods_per_year
-        result[col] = float(abs(1.0 + total) ** (1.0 / years) - 1.0) * (1 if total >= 0 else -1)
+        result[col] = float(abs(1.0 + total) ** (1.0 / years) - 1.0)
     return result
 
 

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -318,11 +318,8 @@ class Data:
         """
         returns_pl = _to_polars(returns)
         benchmark_pl = _to_polars(benchmark) if benchmark is not None else None
-        rf_converted: float | pl.DataFrame
-        if isinstance(rf, pl.DataFrame) or (not isinstance(rf, float) and not isinstance(rf, int)):
-            rf_converted = _to_polars(rf)
-        else:
-            rf_converted = rf  # int is not float/DataFrame: _subtract_risk_free raises TypeError
+        # accept ints (e.g. rf=0) by coercing to float
+        rf_converted: float | pl.DataFrame = float(rf) if isinstance(rf, int | float) else _to_polars(rf)
 
         returns_pl = _apply_null_strategy(returns_pl, date_col, "returns", null_strategy)
         if benchmark_pl is not None:

--- a/tests/test_jquantstats/test__reports/test_reports.py
+++ b/tests/test_jquantstats/test__reports/test_reports.py
@@ -1,7 +1,7 @@
 """Tests for the reports module functionality."""
 
 import math
-from datetime import date
+from datetime import date, timedelta
 
 import plotly.graph_objects as go
 import polars as pl
@@ -242,6 +242,20 @@ def test_cagr_since_single_observation():
     df = pl.DataFrame({"Date": [date(2023, 1, 1)], "ret": [0.01]}).with_columns(pl.col("Date").cast(pl.Date))
     result = _cagr_since(df, "Date", ["ret"], date(2023, 1, 1), 252)
     assert math.isnan(result["ret"])
+
+
+def test_cagr_since_negative_total_return_is_negative():
+    """A losing asset reports a negative annualised return (regression).
+
+    A constant daily loss compounding to exactly -50% over one year of 252
+    observations must produce a CAGR of -50%, not +50%.
+    """
+    n = 252
+    daily = 0.5 ** (1.0 / n) - 1.0  # compounds to exactly -50% over n periods
+    days = [date(2023, 1, 1) + timedelta(days=i) for i in range(n)]
+    df = pl.DataFrame({"Date": days, "ret": [daily] * n})
+    result = _cagr_since(df, "Date", ["ret"], date(2023, 1, 1), 252)
+    assert result["ret"] == pytest.approx(-0.5)
 
 
 def test_metrics_table_html_contains_table_tag():

--- a/tests/test_jquantstats/test_data_from_returns.py
+++ b/tests/test_jquantstats/test_data_from_returns.py
@@ -45,6 +45,22 @@ def test_with_constant_rf(returns):
     assert result.benchmark is None
 
 
+def test_with_integer_rf(returns):
+    """Tests that Data.from_returns accepts an integer risk-free rate.
+
+    Args:
+        returns (pl.DataFrame): The returns fixture containing asset returns.
+
+    Verifies:
+        1. ``rf=0`` (int) behaves exactly like ``rf=0.0`` (float) instead of
+           raising a TypeError (regression).
+
+    """
+    result = Data.from_returns(returns=returns, rf=0, date_col="Date")
+    expected = Data.from_returns(returns=returns, rf=0.0, date_col="Date")
+    assert_frame_equal(result.returns, expected.returns)
+
+
 def test_with_series_rf(returns):
     """Tests that Data.from_returns works with a Series as the risk-free rate.
 

--- a/tests/test_jquantstats/test_edge_cases.py
+++ b/tests/test_jquantstats/test_edge_cases.py
@@ -174,7 +174,7 @@ def test_hhi_negative_nan_few_negatives(edge):
 
 
 def test_subtract_rf_invalid_type():
-    """Tests that Data.from_returns raises TypeError when rf is not a float or DataFrame."""
+    """Tests that Data.from_returns raises TypeError when rf is not numeric or a DataFrame."""
     from datetime import date
 
     returns = pl.DataFrame(
@@ -183,8 +183,8 @@ def test_subtract_rf_invalid_type():
             "asset": [0.01, -0.02],
         }
     )
-    with pytest.raises(TypeError, match="rf must be a float or DataFrame"):
-        Data.from_returns(returns=returns, rf=1)  # int is not float
+    with pytest.raises(TypeError, match="Unsupported dataframe type"):
+        Data.from_returns(returns=returns, rf="not a rate")  # str is neither numeric nor a frame
 
 
 # ── Empty returns ─────────────────────────────────────────────────────────────

--- a/tests/test_jquantstats/test_edge_cases.py
+++ b/tests/test_jquantstats/test_edge_cases.py
@@ -183,7 +183,8 @@ def test_subtract_rf_invalid_type():
             "asset": [0.01, -0.02],
         }
     )
-    with pytest.raises(TypeError, match="Unsupported dataframe type"):
+    # The exact wording comes from narwhals and varies across versions; match loosely.
+    with pytest.raises(TypeError, match="dataframe"):
         Data.from_returns(returns=returns, rf="not a rate")  # str is neither numeric nor a frame
 
 

--- a/tests/test_jquantstats/test_local.py
+++ b/tests/test_jquantstats/test_local.py
@@ -132,3 +132,71 @@ def test_report_html_is_non_empty(client: TestClient, csv_files: dict[str, bytes
         },
     )
     assert len(response.text) > 1_000
+
+
+def test_report_accepts_custom_aum(client: TestClient, csv_files: dict[str, bytes]) -> None:
+    """POST /report accepts an aum form field instead of the hardcoded default."""
+    response = client.post(
+        "/report",
+        files={
+            "prices": ("prices.csv", csv_files["prices"], "text/csv"),
+            "positions": ("positions.csv", csv_files["positions"], "text/csv"),
+        },
+        data={"aum": "500000"},
+    )
+    assert response.status_code == 200
+
+
+def test_report_rejects_nonpositive_aum(client: TestClient, csv_files: dict[str, bytes]) -> None:
+    """POST /report with aum <= 0 fails form validation with 422."""
+    response = client.post(
+        "/report",
+        files={
+            "prices": ("prices.csv", csv_files["prices"], "text/csv"),
+            "positions": ("positions.csv", csv_files["positions"], "text/csv"),
+        },
+        data={"aum": "0"},
+    )
+    assert response.status_code == 422
+
+
+def test_report_invalid_csv_returns_400(client: TestClient) -> None:
+    """POST /report with unparseable CSV content returns 400, not 500."""
+    response = client.post(
+        "/report",
+        files={
+            "prices": ("prices.csv", b"", "text/csv"),
+            "positions": ("positions.csv", b"", "text/csv"),
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_report_inconsistent_data_returns_400(client: TestClient, csv_files: dict[str, bytes]) -> None:
+    """POST /report with CSVs that cannot form a portfolio returns 400, not 500."""
+    positions = b"date,UNKNOWN\n2023-01-02,100\n2023-01-03,100\n"
+    response = client.post(
+        "/report",
+        files={
+            "prices": ("prices.csv", csv_files["prices"], "text/csv"),
+            "positions": ("positions.csv", positions, "text/csv"),
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_report_oversized_upload_returns_413(
+    client: TestClient, csv_files: dict[str, bytes], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /report with a file above the size limit returns 413."""
+    import api.app as app_module
+
+    monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 16)
+    response = client.post(
+        "/report",
+        files={
+            "prices": ("prices.csv", csv_files["prices"], "text/csv"),
+            "positions": ("positions.csv", csv_files["positions"], "text/csv"),
+        },
+    )
+    assert response.status_code == 413


### PR DESCRIPTION
## Summary

Three fixes found during a repo-wide review:

- **CAGR sign flip (bug):** `_cagr_since` in `src/jquantstats/_reports/_data.py` multiplied the annualised return by `-1` whenever the total return was negative. Since `abs(1+total)**(1/years) - 1` is already negative for any loss, this flipped losing assets positive — a −50% one-year return showed as **+50%** in the "3Y (ann.)" / "5Y (ann.)" report rows. The sign factor is removed, matching the existing `Stats.cagr` convention.
- **Integer `rf` raised TypeError (bug):** `Data.from_returns(returns, rf=0)` failed with `TypeError: rf must be a float or DataFrame` while `rf=0.0` worked. Integers are now coerced to float; genuinely invalid types (e.g. strings) still raise `TypeError`.
- **`/report` endpoint hardening:** the FastAPI app (deployed via `railway.toml`) read arbitrary uploads with no size limit, returned bare 500s on any bad input, and hardcoded `aum=1_000_000`. Uploads are now capped at 10 MiB (413), parse/portfolio failures return 400 with a message, and `aum` is a validated form field (`> 0`) defaulting to 1,000,000.

## Tests

- Regression test: `_cagr_since` returns −50% (not +50%) for a one-year −50% asset.
- Regression test: `rf=0` (int) behaves identically to `rf=0.0`.
- Updated `test_subtract_rf_invalid_type` to assert the new contract (string rejected, int accepted).
- New API tests: custom `aum`, non-positive `aum` → 422, empty/invalid CSV → 400, inconsistent portfolio data → 400, oversized upload → 413.

Full suite: 912 passed, 1 skipped (kaleido, expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)