### PR TITLE
test: skip kaleido image-export tests when no browser is available

### DIFF
--- a/tests/test_jquantstats/test__plots/test_kaleido.py
+++ b/tests/test_jquantstats/test__plots/test_kaleido.py
@@ -6,16 +6,44 @@ installed so the base test suite remains dependency-free.
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
 
 kaleido = pytest.importorskip("kaleido", reason="kaleido not installed (pip install jquantstats[plot])")
 
+
+def _chrome_available() -> bool:
+    """Report whether kaleido can locate a Chrome/Chromium to render with.
+
+    kaleido v1 renders images by driving a headless Chrome subprocess. With no
+    browser on the system (and none downloaded via ``plotly_get_chrome``),
+    ``to_image`` / ``write_image`` block until the watchdog kills them — a 300s
+    hang rather than a clean skip. Resolve the browser the same way kaleido does
+    (choreographer's locator, which honours ``$BROWSER_PATH`` and the choreo
+    download cache) so these tests skip cleanly in a browserless dev env while
+    still running on CI runners, which ship Chrome. If the choreographer API
+    ever moves, fall back to *not* skipping so CI coverage is never silently lost.
+    """
+    if os.environ.get("BROWSER_PATH"):
+        return True
+    try:
+        from choreographer.browsers.chromium import chromium_based_browsers, get_browser_path
+
+        return get_browser_path(chromium_based_browsers) is not None
+    except Exception:
+        return True
+
+
 pytestmark = [
     pytest.mark.skipif(
         sys.platform == "win32",
         reason="kaleido launches a Chrome subprocess that crashes the xdist worker on Windows CI",
+    ),
+    pytest.mark.skipif(
+        not _chrome_available(),
+        reason="no Chrome/Chromium found for kaleido (install a browser or run `plotly_get_chrome`)",
     ),
     # The first render pays the Chrome cold-start, which can exceed the
     # global 60s timeout on a busy CI runner (flaked on the v0.9.4 tag build).


### PR DESCRIPTION
## Summary

`make test` failed locally with a **300-second hang** in
`test_kaleido.py::test_portfolio_snapshot_write_image`. Root cause: kaleido v1
renders images by driving a headless **Chrome subprocess**. In a dev
environment where the `plot` extra (kaleido) is installed but no Chrome/Chromium
is present — and none has been downloaded via `plotly_get_chrome` —
`to_image()`/`write_image()` block forever and the `pytest-timeout` watchdog
kills them at 300s. The same tests pass on CI, where GitHub runners ship Chrome.

The existing guards covered *kaleido-not-installed* (`importorskip`) and
*Windows* (`skipif`), but not *kaleido-installed-but-no-browser*.

## Change

`tests/test_jquantstats/test__plots/test_kaleido.py`: add a `_chrome_available()`
helper and a `skipif` marker. It resolves a browser exactly the way kaleido
does — `choreographer.browsers.chromium.get_browser_path(...)`, which honours
`$BROWSER_PATH` and the choreographer download cache — and skips the 5
image-export tests cleanly when none is found. If choreographer's API ever
moves, the helper falls back to **not** skipping, so CI never silently loses
coverage.

## Verification

- Kaleido tests now **skip in 0.05s** with a clear reason instead of the 300s hang.
- `make fmt`: ✅ green.
- `make test`: ✅ exit 0 — **1210 passed, 5 skipped**, no failures.
- Coverage gate: ✅ still **100.00%** (2968/2968) — the skipped tests are not the sole cover for any `src/` line.

Scope: locally-owned `tests/` only; no `src/` or Rhiza-managed files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
