### PR TITLE
refactor: centralize cross-mixin TYPE_CHECKING stubs (closes #834)

### DIFF
--- a/src/jquantstats/_portfolio_attribution.py
+++ b/src/jquantstats/_portfolio_attribution.py
@@ -7,29 +7,14 @@ from typing import TYPE_CHECKING, Self
 import polars as pl
 
 from ._cache import cached_in_slot
-
-if TYPE_CHECKING:
-    pass
+from ._portfolio_base import _PortfolioMembers
 
 
-class PortfolioAttributionMixin:
+class PortfolioAttributionMixin(_PortfolioMembers):
     """Mixin providing tilt/timing attribution properties for Portfolio."""
 
     if TYPE_CHECKING:
-        cashposition: pl.DataFrame
-        prices: pl.DataFrame
-        aum: float
-        cost_per_unit: float
-        cost_bps: float
         _tilt_cache: Self | None
-
-        @property
-        def assets(self) -> list[str]:
-            """Defined on Portfolio."""
-
-        @property
-        def nav_accumulated(self) -> pl.DataFrame:
-            """Defined on PortfolioNavMixin."""
 
         @classmethod
         def from_cash_position(

--- a/src/jquantstats/_portfolio_base.py
+++ b/src/jquantstats/_portfolio_base.py
@@ -1,0 +1,61 @@
+"""Shared type-only declarations for the Portfolio mixins.
+
+The four Portfolio mixins (`PortfolioNavMixin`, `PortfolioAttributionMixin`,
+`PortfolioTurnoverMixin`, `PortfolioCostMixin`) each consume attributes and
+properties that are actually defined on *sibling* mixins or on the composed
+`Portfolio` dataclass itself. So that every mixin type-checks in isolation under
+``mypy --strict``, they all inherit this base, which declares that shared
+surface once under ``TYPE_CHECKING``.
+
+At runtime the body is skipped entirely, so `_PortfolioMembers` is an empty
+class: it adds nothing to instance layout (the mixins are slot-free already) and
+nothing to behaviour — it exists purely to give the type checker a single source
+of truth for the cross-mixin surface instead of repeating the stubs in every
+mixin module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from .data import Data
+
+
+class _PortfolioMembers:
+    """Type-only declaration of the cross-mixin Portfolio surface (see module docstring)."""
+
+    if TYPE_CHECKING:
+        # Raw inputs — real ``Portfolio`` dataclass fields.
+        cashposition: pl.DataFrame
+        prices: pl.DataFrame
+        aum: float
+        cost_per_unit: float
+        cost_bps: float
+
+        # Derived series / accessors defined on sibling mixins or ``Portfolio``.
+        @property
+        def data(self) -> Data:
+            """Bridge to the legacy `Data` object (defined on `Portfolio`)."""
+
+        @property
+        def assets(self) -> list[str]:
+            """Asset column names (defined on `Portfolio`)."""
+
+        @property
+        def returns(self) -> pl.DataFrame:
+            """Daily returns (defined on `PortfolioNavMixin`)."""
+
+        @property
+        def profit(self) -> pl.DataFrame:
+            """Aggregate daily portfolio profit (defined on `PortfolioNavMixin`)."""
+
+        @property
+        def nav_accumulated(self) -> pl.DataFrame:
+            """Cumulative additive NAV (defined on `PortfolioNavMixin`)."""
+
+        @property
+        def turnover(self) -> pl.DataFrame:
+            """Turnover frame (defined on `PortfolioTurnoverMixin`)."""

--- a/src/jquantstats/_portfolio_cost.py
+++ b/src/jquantstats/_portfolio_cost.py
@@ -3,40 +3,15 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING
 
 import polars as pl
 
+from ._portfolio_base import _PortfolioMembers
 from .exceptions import InvalidMaxBpsError, NegativeCostBpsError
 
-if TYPE_CHECKING:
-    from .data import Data
 
-
-class PortfolioCostMixin:
+class PortfolioCostMixin(_PortfolioMembers):
     """Mixin providing cost analysis methods for Portfolio."""
-
-    if TYPE_CHECKING:
-        cashposition: pl.DataFrame
-        aum: float
-        cost_per_unit: float
-        cost_bps: float
-
-        @property
-        def data(self) -> Data:
-            """Defined on Portfolio."""
-
-        @property
-        def returns(self) -> pl.DataFrame:
-            """Defined on PortfolioNavMixin."""
-
-        @property
-        def turnover(self) -> pl.DataFrame:
-            """Defined on PortfolioTurnoverMixin."""
-
-        @property
-        def profit(self) -> pl.DataFrame:
-            """Defined on PortfolioNavMixin."""
 
     @property
     def position_delta_costs(self) -> pl.DataFrame:

--- a/src/jquantstats/_portfolio_nav.py
+++ b/src/jquantstats/_portfolio_nav.py
@@ -7,16 +7,14 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from ._cache import cached_in_slot
+from ._portfolio_base import _PortfolioMembers
 from .exceptions import MissingDateColumnError, NoAssetColumnsError
 
 
-class PortfolioNavMixin:
+class PortfolioNavMixin(_PortfolioMembers):
     """Mixin providing NAV & returns chain properties for Portfolio."""
 
     if TYPE_CHECKING:
-        prices: pl.DataFrame
-        cashposition: pl.DataFrame
-        aum: float
         _profits_cache: pl.DataFrame | None
         _returns_cache: pl.DataFrame | None
 

--- a/src/jquantstats/_portfolio_turnover.py
+++ b/src/jquantstats/_portfolio_turnover.py
@@ -7,14 +7,13 @@ from typing import TYPE_CHECKING
 import polars as pl
 
 from ._cache import cached_in_slot
+from ._portfolio_base import _PortfolioMembers
 
 
-class PortfolioTurnoverMixin:
+class PortfolioTurnoverMixin(_PortfolioMembers):
     """Mixin providing turnover analytics for Portfolio."""
 
     if TYPE_CHECKING:
-        cashposition: pl.DataFrame
-        aum: float
         _turnover_cache: pl.DataFrame | None
 
     @property


### PR DESCRIPTION
Closes #834.

## Summary

The four Portfolio mixins (`PortfolioNavMixin`, `PortfolioAttributionMixin`, `PortfolioTurnoverMixin`, `PortfolioCostMixin`) each carried their own `if TYPE_CHECKING:` block re-declaring the shared surface they consume — the `cashposition`/`prices`/`aum`/`cost_per_unit`/`cost_bps` fields and the cross-mixin `returns`/`profit`/`nav_accumulated`/`turnover`/`data`/`assets` properties. These stubs (added to satisfy `mypy --strict`) were duplicated across modules and prone to drift.

## Change

- New `src/jquantstats/_portfolio_base.py` defining `_PortfolioMembers`: a **type-only** base that declares the cross-mixin surface once under `TYPE_CHECKING`.
- All four mixins now inherit `_PortfolioMembers` and drop their duplicated stubs, keeping only their own mixin-specific declarations (`_*_cache` slots, `_assert_clean_series`, `from_cash_position`).

At runtime the base is an empty class (the mixins are slot-free already, and the body is `TYPE_CHECKING`-guarded), so instance layout, the MRO behaviour, and the public API are unchanged. Net **−51/+8** lines across the mixins.

## Verification

- `make typecheck`: ✅ `ty` all checks passed; `mypy --strict` no issues (38 files).
- `make test`: ✅ 1210 passed, 5 skipped, **100% coverage**.
- `make fmt` / `make deptry`: ✅ clean.

## Acceptance criteria (from #834)

- [x] Per-mixin `TYPE_CHECKING` stub blocks replaced by one shared declaration.
- [x] No behavior change (stubs are type-only; runtime base is empty).
- [x] `make typecheck` (ty + mypy --strict) stays green.
- [x] `make test` stays green at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
