### PR TITLE
test: fix Sharpe scale-invariance property test (closes #836)

### DIFF
--- a/tests/test_jquantstats/test_properties.py
+++ b/tests/test_jquantstats/test_properties.py
@@ -70,6 +70,20 @@ _strictly_negative_returns = st.floats(min_value=-0.1, max_value=-1e-6, allow_na
 # Positive scale factors (used for scale-invariance tests)
 _positive_scale_factor = st.floats(min_value=0.1, max_value=10.0, allow_nan=False, allow_infinity=False)
 
+# Returns conditioned for scale-invariance tests: either exactly zero or a
+# realistic magnitude in [1e-6, 0.1]. This excludes the denormal-magnitude band
+# (|r| ~ 1e-30), where mean/std-ratio metrics like Sharpe become scale-dependent:
+# the negligible-std guard in ``_std_is_negligible`` falls back to an absolute
+# floor (~eps**2) once |mean| drops below one machine epsilon, so scaling such a
+# series can flip the std from "real dispersion" to "rounding noise" (finite
+# Sharpe -> NaN). That regime never occurs in real return data; restricting to it
+# keeps the scale-invariance property meaningful. See #836.
+_scale_safe_returns = st.one_of(
+    st.just(0.0),
+    st.floats(min_value=1e-6, max_value=0.1, allow_nan=False, allow_infinity=False),
+    st.floats(min_value=-0.1, max_value=-1e-6, allow_nan=False, allow_infinity=False),
+)
+
 # Positive prices (used to build synthetic Portfolio instances)
 _pos_price = st.floats(min_value=0.1, max_value=100.0, allow_nan=False, allow_infinity=False)
 
@@ -186,7 +200,7 @@ def test_sortino_nonnegative_for_all_positive_returns(returns: list[float]) -> N
 
 @pytest.mark.property
 @given(
-    returns=st.lists(_general_returns, min_size=10, max_size=50),
+    returns=st.lists(_scale_safe_returns, min_size=10, max_size=50),
     scale=_positive_scale_factor,
 )
 @settings(max_examples=100)


### PR DESCRIPTION
Closes #836.

## Summary

`test_sharpe_scale_invariance` failed deterministically on a hypothesis counterexample:

```
AssertionError: Sharpe NaN-handling not scale-invariant: original=6.04…, scaled=nan (k=0.25)
Falsifying example: returns=[0.0×9, 5.0063e-30], scale=0.25
```

## Root cause (corrected from the issue's first guess)

`5e-30` is a **normal** float, not subnormal — so `allow_subnormal=False` would *not* have fixed it. The real mechanism is in `src/jquantstats/_stats/_core.py::_std_is_negligible`:

```python
return float(std) <= eps * max(abs(mean), eps) * 10.0
```

Once `|mean|` falls below one machine epsilon (~2.2e-16), `max(|mean|, eps)` pins to `eps`, so the threshold collapses to an **absolute floor** `eps²·10 ≈ 5e-31` that is independent of the data scale. The example's std (1.58e-30) sits just above it; scaled by 0.25 the std (3.96e-31) drops just below → the guard reclassifies real dispersion as rounding noise → Sharpe flips finite → `NaN`. This only happens at return magnitudes ~1e-30, which never occur in real data; the heuristic is correct and well-behaved for realistic returns.

## Fix (tests-only)

Add a dedicated `_scale_safe_returns` strategy — either exactly `0.0`, or `|r|` in `[1e-6, 0.1]` — and use it in `test_sharpe_scale_invariance`. This excludes the float-pathology magnitude band while still exercising zeros, positives, negatives, and scale ∈ `[0.1, 10]`. No `src/` change: the negligibility guard's absolute floor is a deliberate near-zero-dispersion guard that's only "wrong" at sub-realistic magnitudes.

## Verification

- `make test`: ✅ 1210 passed, 5 skipped, **100% coverage**.
- `make fmt`: ✅ clean.
- The scale-invariance assertion holds across all 100 hypothesis examples. (Running the test *in isolation* surfaces hypothesis's 200ms cold-start **deadline** as a `FlakyFailure` — a timing artifact of the first polars call, unrelated to the assertion; it does not occur in the warm full suite, which is how CI runs it.)

## Acceptance criteria (from #836)

- [x] `make test` passes (`test_sharpe_scale_invariance` green) across consecutive runs.
- [x] Coverage stays at 100%.
- [x] No `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
