### PR TITLE
Chore: sync Rhiza template v0.19.4 → v0.19.6 + add github-paper

### DIFF
--- a/.claude/commands/rhiza_release.md
+++ b/.claude/commands/rhiza_release.md
@@ -1,0 +1,82 @@
+---
+description: Cut a release — choose the version bump, push the tag, and watch the release workflow
+allowed-tools: Bash, Read
+---
+
+Cut a release for this repository. Follow the command-execution policy: always
+prefer `make <target>`; never invoke `.venv/bin/...` directly.
+
+How releasing works here. `make release` delegates to `rhiza-tools release`
+(`.rhiza/make.d/releasing.mk`). It **always bumps** the version, folds a freshly
+generated `CHANGELOG.md` into the version-bump commit (git-cliff pre-commit
+hook), creates a `v*` tag, and pushes it. The tag push triggers the
+`rhiza_release.yml` GitHub Actions workflow (validate → build → SBOM → draft →
+publish → finalize). There is no separate post-tag changelog commit — the tagged
+commit already carries the changelog.
+
+**The bump type is a user decision.** Run interactively, `make release` prompts
+the user to pick `MAJOR`, `MINOR`, or `PATCH`. Because this command runs in a
+non-interactive shell (where the tool would silently default to `PATCH`), **you
+must ask the user which bump to apply** and pass their choice through with
+`BUMP=major|minor|patch` (supported by both `make release` and `make bump`).
+
+Do the following, in order:
+
+1. **Pre-flight checks.** Confirm the release is safe to cut and stop with a
+   clear explanation if any check fails (do not push a tag from a dirty or
+   behind branch):
+   - Working tree is clean (`git status --porcelain` is empty).
+   - On the default branch (`main`) — or confirm with the user if not.
+   - Local `main` is up to date with `origin/main` (`git fetch` then compare).
+   - `pyproject.toml` exists (the bump is skipped without it).
+
+2. **Ask the user for the bump type.** Just like `make release` does
+   interactively, ask the user to choose **MAJOR**, **MINOR**, or **PATCH**
+   (semver: breaking / feature / fix). Skip this question only when
+   `$ARGUMENTS` already names a bump type or authorises a default (see below).
+   Hold the chosen `<bump>` (lowercase: `major` / `minor` / `patch`) for the
+   next steps.
+
+3. **Preview the bump (dry run).** Run `make release DRY_RUN=1 BUMP=<bump>` to
+   show the user the planned new version and tag **before** anything is pushed.
+   The `DRY_RUN=1` flag previews the bump/tag/push without applying them.
+   Summarise what the real run will do (old → new version, tag name).
+
+4. **Confirm.** Unless `$ARGUMENTS` explicitly authorises proceeding (see
+   below), stop here and ask the user to confirm the previewed version before
+   cutting the real release. Pushing a tag triggers a public release workflow —
+   treat it as outward-facing and confirm first.
+
+5. **Cut the release.** Run `make release BUMP=<bump> PUSH=1`. This bumps,
+   commits (with changelog), tags, and pushes. The `PUSH=1` flag is **required
+   here**: without it the tool asks an interactive `Push tag to remote? [y/N]`
+   question that this non-interactive shell auto-declines, leaving the bump
+   commit and tag stranded locally (unpushed). Since you already confirmed with
+   the user in step 4, `PUSH=1` pushes straight through. Run it in the
+   foreground so any failure is visible. If it fails, show the relevant output,
+   diagnose the root cause, and stop — do not re-run blindly or hand-craft a tag.
+
+6. **Watch the workflow.** Run `make release-status` to show the release
+   workflow run and the latest release info. If the workflow is still in
+   progress, tell the user it is running and how to re-check
+   (`make release-status`). Report the final release URL once available.
+
+7. **Report.** Tell the user the version that was released, the tag, and the
+   release/workflow URL. If anything is still pending (workflow running, draft
+   not yet published), say so plainly.
+
+`$ARGUMENTS` handling:
+
+- Empty → run the full ask-bump → preview → confirm flow above.
+- `major` / `minor` / `patch` → use that as the bump type and skip the question
+  in step 2 (still preview and confirm).
+- `dry-run` (or `preview`) → do steps 1–3 only and stop; do **not** cut a real
+  release. If no bump type is also given, still ask for it in step 2.
+- `yes` / `confirm` / `--force` → skip the interactive confirmation in step 4
+  and proceed straight through (still run the dry-run preview in step 3 so the
+  user sees what shipped). If no bump type is also given, still ask for it in
+  step 2.
+- `status` → skip to step 6 and just report current release/workflow status.
+
+Argument tokens combine, e.g. `minor yes` cuts a minor release without the
+confirmation prompt; `minor dry-run` previews a minor bump only.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,7 +58,7 @@ updates:
         update-types:
           - "patch"
           - "minor"
-          
+
     commit-message:
       prefix: "chore(deps)"
       include: "scope"

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,47 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "Pre-commit hooks" },
+          { "context": "validation" },
+          { "context": "Check dependencies with deptry" },
+          { "context": "docs-coverage" },
+          { "context": "Security scanning" },
+          { "context": "License compliance scan" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.6
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.6
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.6
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.6
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.6
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.6
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.6
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -1,0 +1,34 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: Paper
+#
+# Purpose: Compile the LaTeX paper (docs/paper/*.tex) to a PDF and publish it
+#          as a downloadable workflow artifact. Pushes the PDF to a paper branch.
+#
+# Trigger: On push/PR to main/master when docs/paper/** changes, or manual dispatch.
+
+name: "(RHIZA) PAPER"
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'docs/paper/**'
+      - '.github/workflows/rhiza_paper.yml'
+  workflow_dispatch:
+
+jobs:
+  paper:
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v0.19.6
+    secrets: inherit
+    permissions:
+      contents: write

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.4
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.6
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.6
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.6
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -25,5 +25,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.4
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.6
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.18'
+    rev: 'v0.15.20'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -53,17 +53,11 @@ repos:
 
       - id: check-github-workflows
         args: ["--verbose"]
-        # Generated gh-aw output (DO NOT EDIT headers) uses concurrency keys
-        # ahead of the published workflow schema - the compiler owns its validity
-        exclude: ^\.github/workflows/(.*\.lock\.yml|agentics-maintenance\.yml)$
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
-        # Same carve-out as check-github-workflows above: gh-aw-generated
-        # workflows are owned and validated by the gh-aw compiler
-        exclude: ^\.github/workflows/(.*\.lock\.yml|agentics-maintenance\.yml)$
 
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.25
@@ -77,12 +71,12 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: v1.5.0
+    rev: v1.6.0
     hooks:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.23
+    rev: 0.11.24
     hooks:
       - id: uv-lock
 
@@ -94,7 +88,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.6.3  # Use the latest release
+    rev: v0.7.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/.rhiza/make.d/github.mk
+++ b/.rhiza/make.d/github.mk
@@ -1,0 +1,70 @@
+## github.mk - github repo maintenance and helpers
+# This file is included by the main Makefile
+
+# ── Forge Detection ──────────────────────────────────────────────────────────
+# FORGE_TYPE is set once and reused by any target that needs to know the forge.
+# Priority: .github/workflows/ → .gitlab-ci.yml / .gitlab/ → unknown
+FORGE_TYPE := $(if $(wildcard .github/workflows/),github,$(if $(or $(wildcard .gitlab-ci.yml),$(wildcard .gitlab/)),gitlab,unknown))
+
+# Declare phony targets
+.PHONY: gh-install require-gh view-prs view-issues failed-workflows workflow-status latest-release whoami print-logo
+
+# ── Internal guard ───────────────────────────────────────────────────────────
+# Require the gh CLI; hard-fail if missing so downstream targets can depend on it.
+require-gh:
+	@if ! command -v gh >/dev/null 2>&1; then \
+		printf "${RED}[ERROR] gh cli not found. Install from: https://github.com/cli/cli?tab=readme-ov-file#installation${RESET}\n"; \
+		exit 1; \
+	fi
+
+##@ GitHub Helpers
+gh-install: ## check for gh cli existence and install extensions
+	@if ! command -v gh >/dev/null 2>&1; then \
+		printf "${YELLOW}[WARN] gh cli not found.${RESET}\n"; \
+		printf "${BLUE}[INFO] Please install it from: https://github.com/cli/cli?tab=readme-ov-file#installation${RESET}\n"; \
+	else \
+		printf "${GREEN}[INFO] gh cli is installed.${RESET}\n"; \
+	fi
+
+view-prs: gh-install ## list open pull requests
+	@printf "${BLUE}[INFO] Open Pull Requests:${RESET}\n"
+	@gh pr list --json number,title,author,headRefName,updatedAt --template \
+		'{{tablerow (printf "NUM" | color "bold") (printf "TITLE" | color "bold") (printf "AUTHOR" | color "bold") (printf "BRANCH" | color "bold") (printf "UPDATED" | color "bold")}}{{range .}}{{tablerow (printf "#%v" .number | color "green") .title (.author.login | color "cyan") (.headRefName | color "yellow") (timeago .updatedAt | color "white")}}{{end}}'
+
+view-issues: gh-install ## list open issues
+	@printf "${BLUE}[INFO] Open Issues:${RESET}\n"
+	@gh issue list --json number,title,author,labels,updatedAt --template \
+		'{{tablerow (printf "NUM" | color "bold") (printf "TITLE" | color "bold") (printf "AUTHOR" | color "bold") (printf "LABELS" | color "bold") (printf "UPDATED" | color "bold")}}{{range .}}{{tablerow (printf "#%v" .number | color "green") .title (.author.login | color "cyan") (pluck "name" .labels | join ", " | color "yellow") (timeago .updatedAt | color "white")}}{{end}}'
+
+failed-workflows: gh-install ## list recent failing workflow runs
+	@printf "${BLUE}[INFO] Recent Failing Workflow Runs:${RESET}\n"
+	@gh run list --limit 10 --status failure --json conclusion,name,headBranch,event,createdAt --template \
+		'{{tablerow (printf "STATUS" | color "bold") (printf "NAME" | color "bold") (printf "BRANCH" | color "bold") (printf "EVENT" | color "bold") (printf "TIME" | color "bold")}}{{range .}}{{tablerow (printf "%s" .conclusion | color "red") .name (.headBranch | color "cyan") (.event | color "yellow") (timeago .createdAt | color "white")}}{{end}}'
+
+whoami: gh-install ## check github auth status
+	@printf "${BLUE}[INFO] GitHub Authentication Status:${RESET}\n"
+	@gh auth status --hostname github.com --json hosts --template \
+		'{{range $$host, $$accounts := .hosts}}{{range $$accounts}}{{if .active}}  {{printf "✓" | color "green"}} Logged in to {{$$host}} account {{.login | color "bold"}} ({{.tokenSource}}){{"\n"}}  Active account: {{printf "true" | color "green"}}{{"\n"}}  Git operations protocol: {{.gitProtocol | color "yellow"}}{{"\n"}}  Token scopes: {{.scopes | color "yellow"}}{{"\n"}}{{end}}{{end}}{{end}}'
+
+workflow-status: require-gh ## show recent runs for the release workflow
+	@printf "${BOLD}Release Workflow Status${RESET}\n"
+	@printf "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+	@RELEASE_WF=$$(gh workflow list --json name,id --jq '.[] | select(.name | test("release";"i")) | .name' 2>/dev/null | head -1); \
+	if [ -n "$$RELEASE_WF" ]; then \
+		printf "${BLUE}[INFO] Workflow: ${GREEN}$$RELEASE_WF${RESET}\n\n"; \
+		gh run list --workflow "$$RELEASE_WF" --limit 5 \
+			--json status,conclusion,headBranch,event,createdAt,displayTitle,url \
+			--template '{{tablerow (printf "STATUS" | color "bold") (printf "CONCLUSION" | color "bold") (printf "TITLE" | color "bold") (printf "EVENT" | color "bold") (printf "TIME" | color "bold")}}{{range .}}{{tablerow (printf "%s" .status | color "cyan") (printf "%s" (or .conclusion "—") | color (or (and (eq .conclusion "success") "green") (and (eq .conclusion "failure") "red") "yellow")) .displayTitle (.event | color "yellow") (timeago .createdAt | color "white")}}{{end}}'; \
+	else \
+		printf "${YELLOW}[WARN] No release workflow found in this repository${RESET}\n"; \
+	fi
+
+latest-release: require-gh ## show information about the latest GitHub release
+	@printf "${BOLD}Latest Release${RESET}\n"
+	@printf "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}\n"
+	@if gh release view --json tagName --jq '.tagName' >/dev/null 2>&1; then \
+		gh release view --json tagName,name,publishedAt,url,isDraft,isPrerelease,author \
+			--template '  Tag:          {{.tagName | color "green"}}{{"\n"}}  Name:         {{.name}}{{"\n"}}  Author:       {{.author.login}}{{"\n"}}  Published:    {{timeago .publishedAt}}{{"\n"}}  Status:       {{if .isDraft}}{{printf "Draft" | color "yellow"}}{{else if .isPrerelease}}{{printf "Pre-release" | color "yellow"}}{{else}}{{printf "Published" | color "green"}}{{end}}{{"\n"}}  URL:          {{.url}}{{"\n"}}'; \
+	else \
+		printf "${YELLOW}[WARN] No releases found in this repository${RESET}\n"; \
+	fi

--- a/.rhiza/make.d/github.mk
+++ b/.rhiza/make.d/github.mk
@@ -41,7 +41,7 @@ failed-workflows: gh-install ## list recent failing workflow runs
 	@gh run list --limit 10 --status failure --json conclusion,name,headBranch,event,createdAt --template \
 		'{{tablerow (printf "STATUS" | color "bold") (printf "NAME" | color "bold") (printf "BRANCH" | color "bold") (printf "EVENT" | color "bold") (printf "TIME" | color "bold")}}{{range .}}{{tablerow (printf "%s" .conclusion | color "red") .name (.headBranch | color "cyan") (.event | color "yellow") (timeago .createdAt | color "white")}}{{end}}'
 
-whoami: gh-install ## check github auth status
+whoami: require-gh ## check github auth status
 	@printf "${BLUE}[INFO] GitHub Authentication Status:${RESET}\n"
 	@gh auth status --hostname github.com --json hosts --template \
 		'{{range $$host, $$accounts := .hosts}}{{range $$accounts}}{{if .active}}  {{printf "✓" | color "green"}} Logged in to {{$$host}} account {{.login | color "bold"}} ({{.tokenSource}}){{"\n"}}  Active account: {{printf "true" | color "green"}}{{"\n"}}  Git operations protocol: {{.gitProtocol | color "yellow"}}{{"\n"}}  Token scopes: {{.scopes | color "yellow"}}{{"\n"}}{{end}}{{end}}{{end}}'

--- a/.rhiza/make.d/paper.mk
+++ b/.rhiza/make.d/paper.mk
@@ -1,0 +1,33 @@
+## paper.mk - LaTeX paper compilation targets
+# This file is included by the main Makefile
+
+PAPER_DIR ?= docs/paper
+
+.PHONY: paper paper-clean
+
+##@ Paper
+
+paper:: ## compile LaTeX documents in docs/paper to PDF using latexmk
+	@printf "${BLUE}[INFO] Checking for latexmk...${RESET}\n"
+	@if ! command -v latexmk >/dev/null 2>&1; then \
+	  printf "${RED}[ERROR] latexmk not found. Please install a LaTeX distribution (e.g., MacTeX, TeX Live).${RESET}\n"; \
+	  exit 1; \
+	fi
+	@if [ -z "$$(find $(PAPER_DIR) -maxdepth 1 -name '*.tex' 2>/dev/null)" ]; then \
+	  printf "${YELLOW}[WARN] No .tex files found in $(PAPER_DIR), skipping.${RESET}\n"; \
+	  exit 0; \
+	fi
+	@if [ -f $(PAPER_DIR)/basanos.tex ]; then \
+	  tex_file="basanos.tex"; \
+	else \
+	  tex_file=$$(find $(PAPER_DIR) -maxdepth 1 -name "*.tex" | head -1 | xargs basename); \
+	fi; \
+	printf "${BLUE}[INFO] Compiling $$tex_file...${RESET}\n"; \
+	cd $(PAPER_DIR) && latexmk -pdf -bibtex -interaction=nonstopmode "$$tex_file" || exit 1; \
+	pdf_file="$${tex_file%.tex}.pdf"; \
+	printf "${GREEN}[SUCCESS] $(PAPER_DIR)/$$pdf_file${RESET}\n"
+
+paper-clean:: ## remove latexmk build artifacts in docs/paper
+	@printf "${BLUE}[INFO] Cleaning paper artifacts...${RESET}\n"
+	@cd $(PAPER_DIR) && latexmk -C 2>/dev/null || true
+	@printf "${GREEN}[SUCCESS] Cleaned $(PAPER_DIR)${RESET}\n"

--- a/.rhiza/make.d/paper.mk
+++ b/.rhiza/make.d/paper.mk
@@ -29,5 +29,5 @@ paper:: ## compile LaTeX documents in docs/paper to PDF using latexmk
 
 paper-clean:: ## remove latexmk build artifacts in docs/paper
 	@printf "${BLUE}[INFO] Cleaning paper artifacts...${RESET}\n"
-	@cd $(PAPER_DIR) && latexmk -C 2>/dev/null || true
+	@cd "$(PAPER_DIR)" && latexmk -C 2>/dev/null || true
 	@printf "${GREEN}[SUCCESS] Cleaned $(PAPER_DIR)${RESET}\n"

--- a/.rhiza/make.d/releasing.mk
+++ b/.rhiza/make.d/releasing.mk
@@ -12,13 +12,19 @@ post-release:: ; @:
 
 # DRY_RUN support: pass DRY_RUN=1 to preview changes without applying them
 _DRY_RUN_FLAG := $(if $(DRY_RUN),--dry-run,)
+# BUMP support: pass BUMP=major|minor|patch to choose the bump type explicitly
+# (omit BUMP to select the bump type interactively, the default behaviour)
+_BUMP_FLAG := $(if $(BUMP),--bump $(BUMP),)
+# PUSH support: pass PUSH=1 to push the tag without the interactive y/N prompt
+# (omit PUSH to be prompted before the tag is pushed, the default behaviour)
+_PUSH_FLAG := $(if $(PUSH),--push,)
 _VERSION=0.7.1
 
 ##@ Releasing and Versioning
-bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
+bump: pre-bump ## bump version of the project (supports DRY_RUN=1, BUMP=major|minor|patch)
 	@if [ -f "pyproject.toml" ]; then \
 		$(MAKE) install; \
-		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG); \
+		PATH="$(abspath ${VENV})/bin:$$PATH" ${UVX_BIN} "rhiza-tools>=$(_VERSION)" bump $(_DRY_RUN_FLAG) $(_BUMP_FLAG); \
 		if [ -z "$(DRY_RUN)" ]; then \
 			printf "${BLUE}[INFO] Checking uv.lock file...${RESET}\n"; \
 			${UV_BIN} lock; \
@@ -28,8 +34,8 @@ bump: pre-bump ## bump version of the project (supports DRY_RUN=1)
 	fi
 	@$(MAKE) post-bump
 
-release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1)
-	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG);
+release: pre-release install-uv ## bump version, create tag and push to trigger the release workflow (supports DRY_RUN=1, BUMP=major|minor|patch, PUSH=1)
+	${UVX_BIN} "rhiza-tools>=$(_VERSION)" release $(_DRY_RUN_FLAG) $(_BUMP_FLAG) $(_PUSH_FLAG);
 	@$(MAKE) post-release
 
 release-status: ## show release workflow status and latest release information

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 7fceeb67cbede92474ec7798b0f2945d844b8b3e
+sha: 1a17313aea5af3d15901a77b18f1bff91c7da3a7
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.4
+ref: v0.19.6
 include: []
 exclude: []
 templates:
@@ -10,6 +10,7 @@ files:
 - .bandit
 - .claude/commands/rhiza_book.md
 - .claude/commands/rhiza_quality.md
+- .claude/commands/rhiza_release.md
 - .claude/commands/rhiza_update.md
 - .editorconfig
 - .github/CONFIG.md
@@ -21,6 +22,7 @@ files:
 - .github/dependabot.yml
 - .github/pull_request_template.md
 - .github/release.yml
+- .github/rulesets/main-branch-protection.json
 - .github/secret_scanning.yml
 - .github/workflows/rhiza_benchmark.yml
 - .github/workflows/rhiza_book.yml
@@ -51,6 +53,7 @@ files:
 - .rhiza/make.d/custom-env.mk
 - .rhiza/make.d/custom-task.mk
 - .rhiza/make.d/doctor.mk
+- .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
 - .rhiza/make.d/quality.mk
 - .rhiza/make.d/releasing.mk
@@ -102,5 +105,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-22T19:31:11Z'
+synced_at: '2026-06-27T03:41:31Z'
 strategy: merge

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -6,6 +6,7 @@ include: []
 exclude: []
 templates:
 - legal
+- github-paper
 files:
 - .bandit
 - .claude/commands/rhiza_book.md
@@ -31,6 +32,7 @@ files:
 - .github/workflows/rhiza_fuzzing.yml
 - .github/workflows/rhiza_marimo.yml
 - .github/workflows/rhiza_mutation.yml
+- .github/workflows/rhiza_paper.yml
 - .github/workflows/rhiza_release.yml
 - .github/workflows/rhiza_scorecard.yml
 - .github/workflows/rhiza_sync.yml
@@ -55,6 +57,7 @@ files:
 - .rhiza/make.d/doctor.mk
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
+- .rhiza/make.d/paper.mk
 - .rhiza/make.d/quality.mk
 - .rhiza/make.d/releasing.mk
 - .rhiza/make.d/test.mk
@@ -105,5 +108,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-27T03:41:31Z'
+synced_at: '2026-06-27T03:47:45Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.4"
+ref: "v0.19.6"
 
 profiles:
   - github-project

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -5,3 +5,4 @@ profiles:
   - github-project
 templates:
   - legal
+  - github-paper

--- a/.rhiza/tests/api/conftest.py
+++ b/.rhiza/tests/api/conftest.py
@@ -41,8 +41,6 @@ SPLIT_MAKEFILES = [
     ".rhiza/make.d/marimo.mk",
     ".rhiza/make.d/presentation.mk",
     ".rhiza/make.d/github.mk",
-    ".rhiza/make.d/agentic.mk",
-    ".rhiza/make.d/gh-aw.mk",
     ".rhiza/make.d/docker.mk",
 ]
 

--- a/.rhiza/tests/api/test_github_targets.py
+++ b/.rhiza/tests/api/test_github_targets.py
@@ -6,58 +6,50 @@ and emit the expected commands without actually executing them.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 # Import run_make from local conftest (setup_tmp_makefile is autouse)
 from api.conftest import run_make
 
-_GITHUB_MK = Path(__file__).resolve().parents[3] / ".rhiza" / "make.d" / "github.mk"
-if not _GITHUB_MK.exists():
-    pytest.skip("github.mk not found, skipping github targets tests", allow_module_level=True)
+# Every GitHub helper target defined in github.mk; all must appear in `make help`.
+_GH_TARGETS = (
+    "gh-install",
+    "view-prs",
+    "view-issues",
+    "failed-workflows",
+    "whoami",
+    "workflow-status",
+    "latest-release",
+)
+
+# Map each target to a substring that must appear in its dry-run output, proving
+# the recipe emits the intended command rather than merely parsing. Under `make -n`
+# even @-prefixed recipe lines are printed, so the command text is observable.
+_TARGET_COMMANDS = (
+    ("gh-install", "command -v gh"),
+    ("view-prs", "gh pr list"),
+    ("view-issues", "gh issue list"),
+    ("failed-workflows", "gh run list"),
+    ("whoami", "gh auth status"),
+    ("workflow-status", "gh workflow list"),
+    ("latest-release", "gh release view"),
+)
 
 
 def test_gh_targets_exist(logger):
-    """Verify that GitHub targets are listed in help."""
+    """Verify that every GitHub target is listed in help."""
     result = run_make(logger, ["help"], dry_run=False)
     output = result.stdout
 
-    expected_targets = ["gh-install", "view-prs", "view-issues", "failed-workflows", "whoami"]
-
-    for target in expected_targets:
+    for target in _GH_TARGETS:
         assert target in output, f"Target {target} not found in help output"
 
 
-def test_gh_install_dry_run(logger):
-    """Verify gh-install target dry-run."""
-    result = run_make(logger, ["gh-install"])
-    # In dry-run, we expect to see the shell commands that would be executed.
-    # Since the recipe uses @if, make -n might verify the syntax or show the command if not silenced.
-    # However, with -s (silent), make -n might not show much for @ commands unless they are echoed.
-    # But we mainly want to ensure it runs without error.
+@pytest.mark.parametrize(("target", "expected_command"), _TARGET_COMMANDS)
+def test_gh_target_emits_command(logger, target, expected_command):
+    """Verify each GitHub target dry-runs cleanly and emits its expected command."""
+    result = run_make(logger, [target])
     assert result.returncode == 0
-
-
-def test_view_prs_dry_run(logger):
-    """Verify view-prs target dry-run."""
-    result = run_make(logger, ["view-prs"])
-    assert result.returncode == 0
-
-
-def test_view_issues_dry_run(logger):
-    """Verify view-issues target dry-run."""
-    result = run_make(logger, ["view-issues"])
-    assert result.returncode == 0
-
-
-def test_failed_workflows_dry_run(logger):
-    """Verify failed-workflows target dry-run."""
-    result = run_make(logger, ["failed-workflows"])
-    assert result.returncode == 0
-
-
-def test_whoami_dry_run(logger):
-    """Verify whoami target dry-run."""
-    result = run_make(logger, ["whoami"])
-    assert result.returncode == 0
+    assert expected_command in result.stdout, (
+        f"Target {target} did not emit expected command {expected_command!r}; got:\n{result.stdout}"
+    )

--- a/.rhiza/tests/shell/test_scripts.sh
+++ b/.rhiza/tests/shell/test_scripts.sh
@@ -45,6 +45,7 @@ assert_equal() {
     fi
 }
 
+# shellcheck disable=SC2329  # helper kept for tests that assert on output content
 assert_contains() {
     local haystack="$1"
     local needle="$2"
@@ -93,56 +94,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 echo -e "${BLUE}=== Shell Script Test Suite ===${NC}"
 echo "Repository: $REPO_ROOT"
 echo ""
-
-# ============================================================================
-# Test Suite: session-start.sh
-# ============================================================================
-echo -e "${YELLOW}Testing: session-start.sh${NC}"
-
-# Test 1: Script has proper shebang
-first_line=$(head -n 1 "$REPO_ROOT/.github/hooks/session-start.sh")
-assert_equal "#!/bin/bash" "$first_line" "session-start.sh has bash shebang"
-
-# Test 2: Script uses strict mode
-if grep -q "set -euo pipefail" "$REPO_ROOT/.github/hooks/session-start.sh"; then
-    TESTS_RUN=$((TESTS_RUN + 1))
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-    if [ "$VERBOSE" = true ]; then
-        echo -e "${GREEN}✓${NC} PASS: session-start.sh uses strict error handling"
-    fi
-else
-    TESTS_RUN=$((TESTS_RUN + 1))
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} FAIL: session-start.sh missing 'set -euo pipefail'"
-fi
-
-# Test 3: Normal mode with valid environment
-if [ -d "$REPO_ROOT/.venv" ] && command -v uv >/dev/null 2>&1; then
-    output=$(bash "$REPO_ROOT/.github/hooks/session-start.sh" 2>&1) || true
-    assert_contains "$output" "Validating environment" "session-start.sh normal mode runs validation"
-fi
-
-# ============================================================================
-# Test Suite: session-end.sh
-# ============================================================================
-echo -e "${YELLOW}Testing: session-end.sh${NC}"
-
-# Test 4: Script has proper shebang
-first_line=$(head -n 1 "$REPO_ROOT/.github/hooks/session-end.sh")
-assert_equal "#!/bin/bash" "$first_line" "session-end.sh has bash shebang"
-
-# Test 5: Script uses strict mode
-if grep -q "set -euo pipefail" "$REPO_ROOT/.github/hooks/session-end.sh"; then
-    TESTS_RUN=$((TESTS_RUN + 1))
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-    if [ "$VERBOSE" = true ]; then
-        echo -e "${GREEN}✓${NC} PASS: session-end.sh uses strict error handling"
-    fi
-else
-    TESTS_RUN=$((TESTS_RUN + 1))
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-    echo -e "${RED}✗${NC} FAIL: session-end.sh missing 'set -euo pipefail'"
-fi
 
 # ============================================================================
 # Test Suite: bootstrap.sh
@@ -210,12 +161,11 @@ fi
 # ============================================================================
 echo -e "${YELLOW}Testing: Syntax validation${NC}"
 
-# Test 11-13: Validate syntax of all shell scripts
-for script in \
-    "$REPO_ROOT/.devcontainer/bootstrap.sh" \
-    "$REPO_ROOT/.github/hooks/session-start.sh" \
-    "$REPO_ROOT/.github/hooks/session-end.sh"
-do
+# Validate syntax of all shell scripts
+scripts_to_check=(
+    "$REPO_ROOT/.devcontainer/bootstrap.sh"
+)
+for script in "${scripts_to_check[@]}"; do
     script_name=$(basename "$script")
     if bash -n "$script" 2>/dev/null; then
         TESTS_RUN=$((TESTS_RUN + 1))

--- a/.rhiza/tests/sync/conftest.py
+++ b/.rhiza/tests/sync/conftest.py
@@ -56,7 +56,6 @@ def setup_sync_env(logger, root, tmp_path: Path):
         "marimo.mk",
         "presentation.mk",
         "github.mk",
-        "agentic.mk",
         "docker.mk",
     ]
     (tmp_path / ".rhiza" / "make.d").mkdir(parents=True, exist_ok=True)

--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -22,13 +22,43 @@ _TOOLING: frozenset[str] = frozenset({"pip", "setuptools", "wheel", "distribute"
 
 
 def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
-    """Return a human-readable string of all IDs for a vulnerability entry."""
+    """Return a human-readable string of all IDs for a vulnerability entry.
+
+    Args:
+        vuln: A single vulnerability object from pip-audit's JSON output. Must
+            contain an ``id`` key and may contain an ``aliases`` list.
+
+    Returns:
+        A comma-separated string starting with the primary ``id`` followed by any
+        distinct aliases (e.g. ``"PYSEC-2024-1, CVE-2024-1234"``).
+    """
     ids = [vuln["id"]] + [a for a in vuln.get("aliases", []) if a != vuln["id"]]
     return ", ".join(ids)
 
 
 def main() -> int:
-    """Run pip-audit and apply tiered vulnerability policy."""
+    """Run pip-audit and apply the tiered vulnerability policy.
+
+    Invokes ``uvx pip-audit`` with JSON output, forwarding any extra
+    command-line arguments. Vulnerabilities in build tooling (see ``_TOOLING``)
+    are reported as warnings; vulnerabilities in any other (runtime) dependency
+    are reported as failures.
+
+    Returns:
+        A process exit code: ``0`` when no vulnerabilities affect runtime
+        dependencies (clean run, tooling-only findings, or unparseable output is
+        passed through with pip-audit's own code), or ``1`` when at least one
+        runtime dependency is vulnerable.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make security
+
+        or call pip-audit through this policy directly, forwarding flags::
+
+            $ python .rhiza/utils/pip_audit_policy.py --ignore-vuln CVE-2024-1234
+    """
     uvx = shutil.which("uvx") or "uvx"
     cmd = [uvx, "pip-audit", "--format", "json", *sys.argv[1:]]
     proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -64,7 +64,17 @@ _SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycac
 
 @dataclass
 class Suppression:
-    """Represents a single suppression comment found in the codebase."""
+    """A single suppression comment found in the codebase.
+
+    Attributes:
+        file: Path to the file containing the suppression.
+        line_no: 1-based line number of the comment.
+        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
+            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
+        codes: The specific rule codes named in the comment, if any
+            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
+        raw: The verbatim comment text, used for downstream CVE extraction.
+    """
 
     file: str
     line_no: int
@@ -99,6 +109,13 @@ def scan_file(path: Path) -> list[Suppression]:
     Uses Python's ``tokenize`` module so that only actual comment tokens are
     inspected — patterns that appear inside string literals or docstrings are
     correctly ignored.
+
+    Args:
+        path: Path to the Python file to scan.
+
+    Returns:
+        A list of :class:`Suppression` records, one per matching comment line, in
+        source order. Empty if the file cannot be read or fails to tokenize.
     """
     suppressions: list[Suppression] = []
     try:
@@ -134,7 +151,15 @@ def scan_file(path: Path) -> list[Suppression]:
 
 
 def count_non_empty_lines(path: Path) -> int:
-    """Count non-empty lines in a file."""
+    """Count non-empty lines in a file.
+
+    Args:
+        path: Path to the file to measure.
+
+    Returns:
+        The number of lines that contain non-whitespace characters, or ``0`` if
+        the file cannot be read. Used as the denominator for suppression density.
+    """
     try:
         return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
     except OSError:
@@ -156,7 +181,15 @@ _GRADE_THRESHOLDS: list[tuple[float, str]] = [
 
 
 def compute_grade(density: float) -> str:
-    """Return a letter grade based on suppression density (count per 100 lines)."""
+    """Return a letter grade based on suppression density.
+
+    Args:
+        density: Number of suppressions per 100 non-empty lines of code.
+
+    Returns:
+        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
+        derived from :data:`_GRADE_THRESHOLDS`.
+    """
     grade = "F"
     for threshold, letter in _GRADE_THRESHOLDS:
         if density <= threshold:
@@ -347,7 +380,31 @@ def _check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: lis
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the suppression audit and print a structured report."""
+    """Run the suppression audit and print a structured report.
+
+    Scans the working directory tree for inline suppression comments, prints a
+    per-file report, a histogram by code, and an overall density grade. With
+    ``--fail-stale-nosec-cve`` it additionally cross-checks CVE-tagged ``# nosec``
+    comments against live pip-audit findings and fails on stale ones.
+
+    Args:
+        argv: Argument list to parse (excluding the program name). Defaults to
+            ``None``, in which case ``sys.argv[1:]`` is used by the module entry
+            point. Unrecognised arguments are forwarded to pip-audit.
+
+    Returns:
+        A process exit code: ``0`` on success, ``1`` when stale CVE-tagged
+        ``# nosec`` suppressions are found, or ``2`` when pip-audit fails to run.
+
+    Example:
+        Run via the Makefile (the supported entry point)::
+
+            $ make suppression-audit
+
+        or invoke the module directly, enabling the stale-CVE gate::
+
+            $ python .rhiza/utils/suppression_audit.py --fail-stale-nosec-cve
+    """
     parser = argparse.ArgumentParser(add_help=True)
     parser.add_argument(
         "--fail-stale-nosec-cve",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 ## Makefile (repo-owned)
 # Keep this file small. It can be edited without breaking template sync.
 
-DEFAULT_AI_MODEL=claude-sonnet-4.6
 LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 
 # Override template default: include mkdocstrings plugin for API docs


### PR DESCRIPTION
## Summary

Bumps the Rhiza template pin **v0.19.4 → v0.19.6** and adds the **`github-paper`** template.

### What landed between v0.19.4 and v0.19.6
- `rhiza_release` slash command shipped via the core bundle (`.claude/commands/rhiza_release.md`)
- `.github/rulesets/main-branch-protection.json` added to the github bundle
- `github.mk` moved into the github bundle (`.rhiza/make.d/github.mk`)
- Complete removal of the `gh-aw` bundle upstream
- Dependency bumps: ruff `v0.15.20`, `uv-pre-commit` `v0.11.24`, `rhiza-hooks` `v0.7.0`, `betterleaks` `v1.6.0`, oss-fuzz base-builder digests
- Misc workflow/doc maintenance

### `github-paper` template
Added `github-paper` to `templates:` in `.rhiza/template.yml` (requires the `paper` + `github` bundles). Materialized:
- `.rhiza/make.d/paper.mk` — `make paper` / `make paper-clean` (latexmk-based LaTeX compilation in `docs/paper/`)
- `.github/workflows/rhiza_paper.yml` — caller workflow that compiles `docs/paper/*.tex` to a PDF artifact; only triggers on `docs/paper/**` changes, so it's inert until LaTeX sources are added.

## Conflict resolution
The 3-way merge applied **cleanly — no `*.rej` files and no conflict markers**. All changed files are Rhiza-managed (`.github/*`, `.rhiza/*`, `Makefile`, `.pre-commit-config.yaml`, `.claude/commands/`) and took the upstream side automatically. No locally-owned files (`ruff.toml`, `pyproject.toml`, `src/`, `tests/`) were touched.

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` | ✅ PASS (ty + mypy strict, 49 files) |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS (pip-audit clean, bandit clean) |
| `make test` | ✅ PASS (1210 passed, 5 skipped — kaleido needs Chrome, a pre-existing local env limitation unrelated to this sync) |

No gate fallout to fix; nothing requires an upstream Rhiza change.

## Note
12 workflow files were materialized — pushing them requires a token with the `workflow` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)