### PR TITLE
test: silence incidental BenchmarkAlignmentWarning noise in the suite

### DIFF
--- a/tests/test_jquantstats/conftest.py
+++ b/tests/test_jquantstats/conftest.py
@@ -4,12 +4,14 @@ Security note: Test code uses pytest assertions (S101), which are intentional
 and safe in the test context. No subprocess calls (S603/S607) are used here.
 """
 
+import warnings
 from pathlib import Path
 
 import polars as pl
 import pytest
 
 from jquantstats import Data
+from jquantstats.exceptions import BenchmarkAlignmentWarning
 
 
 @pytest.fixture(scope="session")
@@ -109,7 +111,13 @@ def data(portfolio, benchmark_frame):
         Data: A Data object containing portfolio returns and benchmark data.
 
     """
-    return Data.from_returns(returns=portfolio, benchmark=benchmark_frame)
+    # portfolio.csv and benchmark.csv cover overlapping but not identical date
+    # ranges, so alignment legitimately drops rows. That is incidental to the
+    # many tests that consume this fixture, so suppress the warning at the
+    # source rather than letting it flood the suite output.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BenchmarkAlignmentWarning)
+        return Data.from_returns(returns=portfolio, benchmark=benchmark_frame)
 
 
 @pytest.fixture

--- a/tests/test_jquantstats/test__stats/test_stats.py
+++ b/tests/test_jquantstats/test__stats/test_stats.py
@@ -1,9 +1,13 @@
 """Tests for the stats module."""
 
+import warnings
+
 import numpy as np
 import polars as pl
 import pytest
 from scipy.stats import norm
+
+from jquantstats.exceptions import BenchmarkAlignmentWarning
 
 
 @pytest.fixture
@@ -1481,7 +1485,12 @@ def loss_data(benchmark_frame):
     dates = pl.date_range(pl.date(2020, 1, 1), pl.date(2020, 4, 9), interval="1d", eager=True)[:100]
     df = pl.DataFrame({"Date": dates, "ret": pl.Series([0.01] * 99 + [-1.0])})
     bench = benchmark_frame.filter(pl.col("Date").is_between(dates[0], dates[-1]))
-    return Data.from_returns(returns=df, benchmark=bench)
+    # The synthetic returns and the filtered benchmark do not share every date,
+    # so alignment drops rows. That is incidental to the -100%-loss scenario
+    # under test, so suppress the warning at the source.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BenchmarkAlignmentWarning)
+        return Data.from_returns(returns=df, benchmark=bench)
 
 
 @pytest.fixture

--- a/tests/test_jquantstats/test_data_from_returns.py
+++ b/tests/test_jquantstats/test_data_from_returns.py
@@ -93,6 +93,7 @@ def test_pandas_input(returns):
     assert_frame_equal(d.returns, returns.drop("Date"))
 
 
+@pytest.mark.filterwarnings("ignore::jquantstats.exceptions.BenchmarkAlignmentWarning")
 def test_with_benchmark(returns, benchmark_frame):
     """Tests that Data.from_returns correctly handles a benchmark.
 
@@ -167,6 +168,7 @@ def test_from_returns_pandas_input(returns):
     assert_frame_equal(d.returns, returns.drop("Date"))
 
 
+@pytest.mark.filterwarnings("ignore::jquantstats.exceptions.BenchmarkAlignmentWarning")
 def test_from_returns_with_benchmark(returns, benchmark_frame):
     """Data.from_returns with benchmark correctly stores benchmark."""
     d = Data.from_returns(returns=returns, benchmark=benchmark_frame)

--- a/tests/test_jquantstats/test_edge_cases.py
+++ b/tests/test_jquantstats/test_edge_cases.py
@@ -8,6 +8,7 @@ import pytest
 from polars.testing import assert_frame_equal
 
 from jquantstats.data import Data
+from jquantstats.exceptions import BenchmarkAlignmentWarning
 
 
 @pytest.fixture
@@ -332,7 +333,10 @@ def test_partial_date_overlap_aligns_correctly():
         pl.col("Date").str.to_date()
     )
 
-    data = Data.from_returns(returns=returns, benchmark=benchmark)
+    # The partial overlap must surface a BenchmarkAlignmentWarning so dropped
+    # rows cannot truncate the analysis unnoticed.
+    with pytest.warns(BenchmarkAlignmentWarning):
+        data = Data.from_returns(returns=returns, benchmark=benchmark)
 
     assert data.returns.shape[0] == 6
     assert data.benchmark is not None
@@ -463,8 +467,13 @@ def test_null_strategy_nan_not_affected_by_null_strategy():
     assert data_drop.returns.shape[0] == 3
 
 
+@pytest.mark.filterwarnings("ignore::jquantstats.exceptions.BenchmarkAlignmentWarning")
 def test_null_strategy_applied_to_benchmark():
-    """null_strategy is applied to benchmark as well as returns."""
+    """null_strategy is applied to benchmark as well as returns.
+
+    Dropping the null benchmark row leaves returns and benchmark misaligned;
+    that alignment warning is incidental to the null-handling under test.
+    """
     from datetime import date, timedelta
 
     from jquantstats.exceptions import NullsInReturnsError


### PR DESCRIPTION
## Summary

The test suite emitted **414 `BenchmarkAlignmentWarning`** instances, nearly all from fixtures and tests that deliberately feed misaligned returns/benchmark data where the dropped rows are incidental to what's under test. This cleans up the noise while keeping the warning path covered.

## Approach (no blanket suppression)

| Site | Treatment | Why |
|------|-----------|-----|
| `conftest.py` `data` fixture | Suppress at source (`warnings.catch_warnings`) | Dominant volume — consumed by hundreds of tests; `portfolio.csv`/`benchmark.csv` overlap but aren't identical |
| `test_stats.py` `loss_data` fixture | Suppress at source | Filtered benchmark vs synthetic returns; incidental to the −100%-loss scenario |
| `test_data_from_returns.py` (×2) | `filterwarnings` marker | Tests benchmark *storage*, not alignment |
| `test_edge_cases.py` null-strategy test | `filterwarnings` marker | Alignment drop is a side-effect of null dropping |
| `test_edge_cases.py::test_partial_date_overlap_aligns_correctly` | **`pytest.warns`** | Genuinely tests alignment — now *asserts* the warning fires, so a regression that stopped emitting it would fail the suite |

## Verification

- `make test` — ✅ **1210 passed, 5 skipped, 100% coverage**; warnings summary gone (only the unavoidable `PytestBenchmarkWarning` from xdist-disabled benchmarks remains — Rhiza-owned tooling).
- `make fmt` — ✅ pass (ruff check + format clean with the new imports/markers).

Test-only change: 4 files, +32/−4, no `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)