### PR TITLE
refactor(exceptions): reduce noqa[TRY003] density via reusable exception subclasses

### DIFF
--- a/src/jquantstats/_plots/_data/_rolling.py
+++ b/src/jquantstats/_plots/_data/_rolling.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import plotly.graph_objects as go
 import polars as pl
 
+from jquantstats.exceptions import NoBenchmarkError
+
 from ._styling import _apply_base_layout, _apply_figsize, _ticker_colors
 
 if TYPE_CHECKING:
@@ -214,7 +216,7 @@ class _RollingPlotsMixin:
 
         benchmark_df = getattr(self._data, "benchmark", None)
         if benchmark_df is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
 
         bench_col = benchmark_df.columns[0]
         returns_df = getattr(self._data, "returns", None)

--- a/src/jquantstats/_stats/_montecarlo.py
+++ b/src/jquantstats/_stats/_montecarlo.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 
+from ..exceptions import NonPositivePeriodsPerYearError, NonPositiveWindowError
+
 if TYPE_CHECKING:
     from ..data import Data
 
@@ -27,7 +29,7 @@ class _MonteCarloStatsMixin:
     def _validate_positive_integer(name: str, value: int) -> int:
         """Validate that *value* is a positive integer."""
         if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-            raise ValueError(f"{name} must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError(name)
         return value
 
     @staticmethod
@@ -136,7 +138,7 @@ class _MonteCarloStatsMixin:
         """
         ppy = self._data._periods_per_year if periods_per_year is None else periods_per_year
         if ppy <= 0:
-            raise ValueError("periods_per_year must be positive")  # noqa: TRY003
+            raise NonPositivePeriodsPerYearError
         scale = math.sqrt(ppy)
         paths = self._simulate_distribution(n=n, period=period)
         result: dict[str, np.ndarray] = {}
@@ -196,7 +198,7 @@ class _MonteCarloStatsMixin:
         """
         ppy = self._data._periods_per_year if periods_per_year is None else periods_per_year
         if ppy <= 0:
-            raise ValueError("periods_per_year must be positive")  # noqa: TRY003
+            raise NonPositivePeriodsPerYearError
         years = period / ppy
         paths = self._simulate_distribution(n=n, period=period)
         result: dict[str, np.ndarray] = {}

--- a/src/jquantstats/_stats/_performance.py
+++ b/src/jquantstats/_stats/_performance.py
@@ -9,6 +9,7 @@ import numpy as np
 import polars as pl
 from scipy.stats import norm
 
+from ..exceptions import NoBenchmarkError
 from ._core import _mean, _std_is_negligible, _to_float, columnwise_stat
 from ._internals import _annualization_factor, _comp_return, _downside_deviation
 
@@ -543,7 +544,7 @@ class _RiskStatsMixin:
 
         """
         if self._data.benchmark is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
 
         benchmark_col = benchmark or self._data.benchmark.columns[0]
 
@@ -587,7 +588,7 @@ class _RiskStatsMixin:
 
         """
         if self._data.benchmark is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
 
         ppy = periods_per_year or self._data._periods_per_year
 
@@ -682,7 +683,7 @@ class _RiskStatsMixin:
             series is empty, or the compounded NAV is non-positive.
         """
         if self._data.benchmark is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
 
         ppy = periods or self._data._periods_per_year
 

--- a/src/jquantstats/_stats/_periodic.py
+++ b/src/jquantstats/_stats/_periodic.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, cast
 
 import polars as pl
 
+from ..exceptions import NoBenchmarkError
+
 if TYPE_CHECKING:
     from ..data import Data
 
@@ -195,7 +197,7 @@ class _PeriodicReportingMixin:
 
         """
         if self._data.benchmark is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
 
         all_df = self.all
         date_col_name = self._data.date_col[0]

--- a/src/jquantstats/_stats/_rolling.py
+++ b/src/jquantstats/_stats/_rolling.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import polars as pl
 
+from ..exceptions import NoBenchmarkError, NonPositiveWindowError
 from ._core import _to_float
 from ._drawdown import _DrawdownMixin
 from ._internals import _annualization_factor
@@ -106,7 +107,7 @@ class _RollingStatsMixin:
 
         """
         if not isinstance(window, int) or window <= 0:
-            raise ValueError("window must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError("window")
 
         cols: list[pl.Expr | pl.Series] = [pl.col(name) for name in self._data.date_col]
         for col, series in self._data.items():
@@ -139,7 +140,7 @@ class _RollingStatsMixin:
 
         """
         if not isinstance(rolling_period, int) or rolling_period <= 0:
-            raise ValueError("rolling_period must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError("rolling_period")
         ppy = periods_per_year or self._data._periods_per_year
         scale = _annualization_factor(ppy)
         exprs: list[pl.Expr] = []
@@ -172,7 +173,7 @@ class _RollingStatsMixin:
         actual_window = rolling_period
         actual_periods = periods_per_year or self._data._periods_per_year
         if not isinstance(actual_window, int) or actual_window <= 0:
-            raise ValueError("rolling_period must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError("rolling_period")
         scale = _annualization_factor(actual_periods)
         return self.all.select(
             [pl.col(name) for name in self._data.date_col]
@@ -215,9 +216,9 @@ class _RollingStatsMixin:
             ValueError: If *rolling_period* is not a positive integer.
         """
         if self._data.benchmark is None:
-            raise AttributeError("No benchmark data available")  # noqa: TRY003
+            raise NoBenchmarkError
         if not isinstance(rolling_period, int) or rolling_period <= 0:
-            raise ValueError("rolling_period must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError("rolling_period")
 
         ppy = periods_per_year or self._data._periods_per_year
         all_df = self.all
@@ -268,7 +269,7 @@ class _RollingStatsMixin:
         actual_window = rolling_period
         actual_periods = periods_per_year or self._data._periods_per_year
         if not isinstance(actual_window, int) or actual_window <= 0:
-            raise ValueError("rolling_period must be a positive integer")  # noqa: TRY003
+            raise NonPositiveWindowError("rolling_period")
         if not isinstance(actual_periods, int | float):
             raise TypeError
         factor = _annualization_factor(actual_periods) if annualize else 1.0

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -12,7 +12,12 @@ import narwhals as nw
 import polars as pl
 
 from ._types import NativeFrame, NativeFrameOrScalar
-from .exceptions import BenchmarkAlignmentWarning, MissingDateColumnError, NullsInReturnsError
+from .exceptions import (
+    BenchmarkAlignmentWarning,
+    IntegerIndexBoundError,
+    MissingDateColumnError,
+    NullsInReturnsError,
+)
 
 if TYPE_CHECKING:
     from ._plots import DataPlots
@@ -701,9 +706,9 @@ class Data:
             new_benchmark = self.benchmark.filter(mask) if self.benchmark is not None else None
         else:
             if start is not None and not isinstance(start, int):
-                raise TypeError(f"start must be an integer, got {type(start).__name__}.")  # noqa: TRY003
+                raise IntegerIndexBoundError("start", type(start).__name__)
             if end is not None and not isinstance(end, int):
-                raise TypeError(f"end must be an integer, got {type(end).__name__}.")  # noqa: TRY003
+                raise IntegerIndexBoundError("end", type(end).__name__)
             row_start = start if start is not None else 0
             row_end = end + 1 if end is not None else self.index.height
             length = max(0, row_end - row_start)

--- a/src/jquantstats/exceptions.py
+++ b/src/jquantstats/exceptions.py
@@ -329,6 +329,59 @@ class NullsInReturnsError(JQuantStatsError, ValueError):
         self.columns = columns
 
 
+class NoBenchmarkError(JQuantStatsError, AttributeError):
+    """Raised when a benchmark-dependent statistic is requested without a benchmark.
+
+    Subclasses `AttributeError` so existing callers that catch
+    ``AttributeError`` for the no-benchmark path keep working unchanged.
+
+    Examples:
+        >>> raise NoBenchmarkError()
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.NoBenchmarkError: No benchmark data available
+    """
+
+    def __init__(self) -> None:
+        """Initialize with the fixed no-benchmark message."""
+        super().__init__("No benchmark data available")
+
+
+class NonPositiveWindowError(JQuantStatsError, ValueError):
+    """Raised when a rolling-window size is not a positive integer.
+
+    Args:
+        param: Name of the offending parameter (e.g. ``"window"`` or
+            ``"rolling_period"``).
+
+    Examples:
+        >>> raise NonPositiveWindowError("window")
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.NonPositiveWindowError: window must be a positive integer
+    """
+
+    def __init__(self, param: str) -> None:
+        """Initialize with the name of the offending window parameter."""
+        super().__init__(f"{param} must be a positive integer")
+        self.param = param
+
+
+class NonPositivePeriodsPerYearError(JQuantStatsError, ValueError):
+    """Raised when ``periods_per_year`` is not strictly positive.
+
+    Examples:
+        >>> raise NonPositivePeriodsPerYearError()
+        Traceback (most recent call last):
+            ...
+        jquantstats.exceptions.NonPositivePeriodsPerYearError: periods_per_year must be positive
+    """
+
+    def __init__(self) -> None:
+        """Initialize with the fixed non-positive periods-per-year message."""
+        super().__init__("periods_per_year must be positive")
+
+
 class BenchmarkAlignmentWarning(UserWarning):
     """Emitted when aligning returns and benchmark drops rows from either side.
 


### PR DESCRIPTION
Closes #856

## Summary
Reduces inline-suppression density by replacing the most-repeated literal exception messages (the dominant `noqa[TRY003]` contributor) with reusable, message-bearing subclasses in `src/jquantstats/exceptions.py`:

- **`NoBenchmarkError`** (subclasses `AttributeError`) — 6 sites previously raising `AttributeError("No benchmark data available")` in `_stats/_rolling.py`, `_stats/_performance.py` (×3), `_stats/_periodic.py`, and `_plots/_data/_rolling.py`.
- **`NonPositiveWindowError(param)`** (subclasses `ValueError`) — `"{param} must be a positive integer"`: the `window`/`rolling_period` checks in `_stats/_rolling.py` (×5) and the montecarlo positive-integer validator (×1).
- **`NonPositivePeriodsPerYearError`** (subclasses `ValueError`) — the two `"periods_per_year must be positive"` sites in `_stats/_montecarlo.py`.
- Reused the **existing** `IntegerIndexBoundError` for the duplicated `start`/`end` integer-bound checks in `data.py` (×2), which `_portfolio_transform.py` already uses.

Each new class preserves the **exact** message string and base exception type, so all existing `pytest.raises(..., match=...)` assertions (including the mutation-kill suites) continue to pass unchanged.

## Suppression audit (before / after)
- Real committed `src/` suppressions: **74 → 58** (~22% reduction); `noqa[TRY003]` is the bulk of the drop.
- `make suppression-audit` total: 148 → 132; density 0.70 → 0.62; **Grade B** (unchanged label).

The reported grade stays B because the audit also scans a stale local git worktree (`.worktrees/r3`, gitignored, on an older branch) that mirrors `src/` and roughly **doubles** the count — as the issue itself notes. That worktree does not exist in CI/clean clones, so the metric CI sees reflects only the reduced real `src/` tree. I deliberately did **not** edit `.rhiza/` audit tooling (rhiza-synced) or touch the user's local worktree to game the number.

This satisfies the acceptance criterion's alternative: "the suppression count in `src/` is materially reduced with each remaining suppression justified." Remaining `noqa[TRY003]` are individually-distinct, defensible messages; remaining `# no cover` are documented degenerate-input / unreachable defensive guards (left in place per the issue's guidance).

## Gate results
- `make fmt` — PASS
- `make test` — PASS (1210 passed, 5 skipped; 100% coverage — new exception classes fully exercised by existing tests)
- `make typecheck` — PASS (ty + mypy strict)
- `make security` — PASS (S110/B110 untouched; covered by #855)