### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+Closes #<!-- issue number -->
+
+## Changes
+
+<!-- Bullet list of what changed. -->
+
+-
+
+## Testing
+
+- [ ] `make test` passes locally
+- [ ] `make fmt` has been run
+- [ ] New tests added (or explain why not needed)
+
+## Checklist
+
+- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
+- [ ] `CHANGELOG.md` entry added (or not needed for this change)
+- [ ] Documentation updated if behaviour changed
+- [ ] `make deptry` passes (no unused or missing dependencies)

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -110,5 +110,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T13:14:50Z'
+synced_at: '2026-07-06T00:18:56Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **1** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### GitHub Configuration

<details>
<summary>Added (1)</summary>

- ✅ `.github/pull_request_template.md`

</details>

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@v0.19.9`
- Last sync: 2026-07-06T00:18:56Z
- Sync date: 2026-07-06T00:18:57.960003+00:00