### PR TITLE
refactor: decompose C-grade blocks to reduce cyclomatic complexity (#863)

### DIFF
--- a/src/jquantstats/_plots/_data/_dashboard.py
+++ b/src/jquantstats/_plots/_data/_dashboard.py
@@ -47,7 +47,34 @@ def _plot_performance_dashboard(returns: pl.DataFrame, log_scale: bool = False) 
         vertical_spacing=0.05,
     )
 
-    # --- Row 1: Cumulative Returns
+    _add_cumulative_traces(fig, prices, date_col, tickers, colors)
+    _add_drawdown_traces(fig, prices, date_col, tickers, colors)
+    fig.add_hline(y=0, line_width=1, line_color="gray", row=2, col=1)
+    _add_monthly_traces(fig, monthly_returns, date_col, tickers, colors)
+
+    _apply_base_layout(fig, f"{' vs '.join(tickers)} Performance Dashboard", height=1200)
+
+    fig.update_yaxes(title_text="Cumulative Return", row=1, col=1, tickformat=".2f")
+    fig.update_yaxes(title_text="Drawdown", row=2, col=1, tickformat=".0%")
+    fig.update_yaxes(title_text="Monthly Return", row=3, col=1, tickformat=".0%")
+
+    fig.update_xaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
+    fig.update_yaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
+
+    if log_scale:
+        fig.update_yaxes(type="log", row=1, col=1)
+
+    return fig
+
+
+def _add_cumulative_traces(
+    fig: go.Figure,
+    prices: pl.DataFrame,
+    date_col: str,
+    tickers: list[str],
+    colors: dict[str, str],
+) -> None:
+    """Add the row-1 cumulative-return line traces (one per ticker)."""
     for ticker in tickers:
         price_col = f"{ticker}_price"
         fig.add_trace(
@@ -65,7 +92,15 @@ def _plot_performance_dashboard(returns: pl.DataFrame, log_scale: bool = False) 
             col=1,
         )
 
-    # --- Row 2: Drawdowns
+
+def _add_drawdown_traces(
+    fig: go.Figure,
+    prices: pl.DataFrame,
+    date_col: str,
+    tickers: list[str],
+    colors: dict[str, str],
+) -> None:
+    """Add the row-2 drawdown area traces (one per ticker)."""
     for ticker in tickers:
         price_col = f"{ticker}_price"
         # Calculate drawdowns using polars
@@ -90,9 +125,15 @@ def _plot_performance_dashboard(returns: pl.DataFrame, log_scale: bool = False) 
             col=1,
         )
 
-    fig.add_hline(y=0, line_width=1, line_color="gray", row=2, col=1)
 
-    # --- Row 3: Monthly Returns
+def _add_monthly_traces(
+    fig: go.Figure,
+    monthly_returns: pl.DataFrame,
+    date_col: str,
+    tickers: list[str],
+    colors: dict[str, str],
+) -> None:
+    """Add the row-3 monthly-return bar traces (one per ticker)."""
     for ticker in tickers:
         # Get monthly returns values as a list for coloring
         monthly_values = monthly_returns[ticker].to_list()
@@ -120,17 +161,3 @@ def _plot_performance_dashboard(returns: pl.DataFrame, log_scale: bool = False) 
             row=3,
             col=1,
         )
-
-    _apply_base_layout(fig, f"{' vs '.join(tickers)} Performance Dashboard", height=1200)
-
-    fig.update_yaxes(title_text="Cumulative Return", row=1, col=1, tickformat=".2f")
-    fig.update_yaxes(title_text="Drawdown", row=2, col=1, tickformat=".0%")
-    fig.update_yaxes(title_text="Monthly Return", row=3, col=1, tickformat=".0%")
-
-    fig.update_xaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
-    fig.update_yaxes(showgrid=True, gridwidth=0.5, gridcolor="lightgrey")
-
-    if log_scale:
-        fig.update_yaxes(type="log", row=1, col=1)
-
-    return fig

--- a/src/jquantstats/_plots/_data/_periodic.py
+++ b/src/jquantstats/_plots/_data/_periodic.py
@@ -13,6 +13,32 @@ if TYPE_CHECKING:
     from jquantstats._protocol import DataLike
 
 
+def _monthly_heatmap_matrix(
+    monthly: pl.DataFrame, years: list[int]
+) -> tuple[list[list[float | None]], list[list[str]]]:
+    """Build the year-by-month value and label grids for the monthly heatmap.
+
+    Args:
+        monthly: Aggregated frame with ``_year``, ``_month`` and ``ret`` columns.
+        years: Sorted unique years, defining the row order of the output grids.
+
+    Returns:
+        A ``(z, text)`` tuple: ``z`` holds returns scaled to percent (``None``
+        for missing cells) and ``text`` the formatted per-cell labels.
+
+    """
+    year_idx = {y: i for i, y in enumerate(years)}
+    z: list[list[float | None]] = [[None] * 12 for _ in years]
+    text: list[list[str]] = [[""] * 12 for _ in years]
+    for row in monthly.iter_rows(named=True):
+        yi = year_idx[row["_year"]]
+        mi = row["_month"] - 1
+        val = row["ret"]
+        z[yi][mi] = val * 100 if val is not None else None
+        text[yi][mi] = f"{val:.1%}" if val is not None else ""
+    return z, text
+
+
 class _PeriodicPlotsMixin:
     """Daily/monthly/yearly bar charts and the monthly heatmap for :class:`DataPlots`."""
 
@@ -193,16 +219,7 @@ class _PeriodicPlotsMixin:
         )
 
         years = sorted(monthly["_year"].unique().to_list())
-        z = [[None] * 12 for _ in years]
-        text = [[""] * 12 for _ in years]
-        year_idx = {y: i for i, y in enumerate(years)}
-
-        for row in monthly.iter_rows(named=True):
-            yi = year_idx[row["_year"]]
-            mi = row["_month"] - 1
-            val = row["ret"]
-            z[yi][mi] = val * 100 if val is not None else None
-            text[yi][mi] = f"{val:.1%}" if val is not None else ""
+        z, text = _monthly_heatmap_matrix(monthly, years)
 
         fig = go.Figure(
             go.Heatmap(

--- a/src/jquantstats/_portfolio_constructors.py
+++ b/src/jquantstats/_portfolio_constructors.py
@@ -43,6 +43,43 @@ def _evaluate_position_expr(prices: pl.DataFrame, expr: pl.Expr, param: str) -> 
     return evaluated
 
 
+def _validate_vol_cap(vol_cap: float | None) -> None:
+    """Validate the optional ``vol_cap`` lower bound.
+
+    Args:
+        vol_cap: Candidate lower bound for the EWMA volatility estimate.
+
+    Raises:
+        ValueError: If *vol_cap* is provided but not strictly positive.
+    """
+    if vol_cap is not None and vol_cap <= 0:
+        raise ValueError(f"vol_cap must be a positive number when provided, got {vol_cap!r}")  # noqa: TRY003
+
+
+def _validate_vola(vola: int | dict[str, int], assets: list[str]) -> None:
+    """Validate the EWMA ``vola`` span specification against the asset columns.
+
+    Args:
+        vola: A single span applied to every asset, or a per-asset span dict.
+        assets: Numeric column names available in the price frame.
+
+    Raises:
+        ValueError: If a dict key matches no numeric column, or any span is
+            not a positive integer.
+    """
+    if isinstance(vola, dict):
+        unknown = set(vola.keys()) - set(assets)
+        if unknown:
+            raise ValueError(  # noqa: TRY003
+                f"vola dict contains keys that do not match any numeric column in prices: {sorted(unknown)}"
+            )
+        for asset, span in vola.items():
+            if int(span) <= 0:
+                raise ValueError(f"vola span for '{asset}' must be a positive integer, got {span!r}")  # noqa: TRY003
+    elif int(vola) <= 0:
+        raise ValueError(f"vola span must be a positive integer, got {vola!r}")  # noqa: TRY003
+
+
 class PortfolioConstructorMixin(_PortfolioMembers):
     """Mixin providing the risk- and notional-position factory classmethods."""
 
@@ -122,23 +159,8 @@ class PortfolioConstructorMixin(_PortfolioMembers):
             cost_bps = cost_model.cost_bps
         assets = [col for col, dtype in prices.schema.items() if dtype.is_numeric()]
 
-        # ── Validate vol_cap ──────────────────────────────────────────────────
-        if vol_cap is not None and vol_cap <= 0:
-            raise ValueError(f"vol_cap must be a positive number when provided, got {vol_cap!r}")  # noqa: TRY003
-
-        # ── Validate vola ─────────────────────────────────────────────────────
-        if isinstance(vola, dict):
-            unknown = set(vola.keys()) - set(assets)
-            if unknown:
-                raise ValueError(  # noqa: TRY003
-                    f"vola dict contains keys that do not match any numeric column in prices: {sorted(unknown)}"
-                )
-            for asset, span in vola.items():
-                if int(span) <= 0:
-                    raise ValueError(f"vola span for '{asset}' must be a positive integer, got {span!r}")  # noqa: TRY003
-        else:
-            if int(vola) <= 0:
-                raise ValueError(f"vola span must be a positive integer, got {vola!r}")  # noqa: TRY003
+        _validate_vol_cap(vol_cap)
+        _validate_vola(vola, assets)
 
         def _span(asset: str) -> int:
             """Return the EWMA span for *asset*, falling back to 32 if not specified."""

--- a/src/jquantstats/_reports/_data.py
+++ b/src/jquantstats/_reports/_data.py
@@ -121,54 +121,14 @@ class Reports:
 
         # ── Period info for header ────────────────────────────────────────────
         all_df: pl.DataFrame | None = getattr(self._data, "all", None)
-        period_info = ""
-        temporal_index = False
-        if all_df is not None:  # pragma: no branch — Data always exposes .all; getattr default is defensive
-            date_col = all_df.columns[0]
-            temporal_index = all_df[date_col].dtype.is_temporal()
-            if temporal_index:
-                start_dt = all_df[date_col].min()
-                end_dt = all_df[date_col].max()
-                n = len(all_df)
-                period_info = f"{start_dt!s} → {end_dt!s} | {n:,} observations"
+        period_info, temporal_index = _report_period_info(all_df)
 
         # ── Drawdowns ─────────────────────────────────────────────────────────
         drawdowns_html = _drawdowns_section_html(self._data, assets)
 
         # ── Charts ────────────────────────────────────────────────────────────
         plots = getattr(self._data, "plots", None)
-        chart_parts: list[str] = []
-        if plots is not None:  # pragma: no branch — Data always exposes .plots; getattr default is defensive
-            _chart_methods: list[tuple[str, dict[str, Any]]] = [
-                ("snapshot", {}),
-                ("returns", {}),
-                ("drawdown", {}),
-                ("rolling_sharpe", {}),
-                ("rolling_volatility", {}),
-                ("monthly_heatmap", {}),
-                ("yearly_returns", {}),
-                ("histogram", {}),
-            ]
-            # These charts aggregate by calendar period (resample, dt.year/
-            # dt.month) and cannot be computed for an integer index.
-            _calendar_charts = {"snapshot", "monthly_heatmap", "yearly_returns"}
-            if not temporal_index:
-                skipped = ", ".join(m for m, _ in _chart_methods if m in _calendar_charts)
-                warnings.warn(
-                    f"Index is not temporal; skipping calendar-based charts: {skipped}.",
-                    stacklevel=2,
-                )
-            for method, kwargs in _chart_methods:
-                if not temporal_index and method in _calendar_charts:
-                    continue
-                fn = getattr(plots, method, None)
-                if fn is None:
-                    continue
-                div = _try_plotly_div(fn(**kwargs), include_cdn=not chart_parts)
-                if div:  # pragma: no branch — _try_plotly_div only returns falsy on render failure
-                    chart_parts.append(f'<div style="margin-bottom:24px">{div}</div>')
-
-        charts_html = "\n".join(chart_parts) if chart_parts else "<p>No charts available.</p>"
+        charts_html = _report_charts_html(plots, temporal_index)
 
         return _build_full_html(
             title=title,
@@ -178,3 +138,98 @@ class Reports:
             drawdowns_html=drawdowns_html,
             charts_html=charts_html,
         )
+
+
+def _report_period_info(all_df: pl.DataFrame | None) -> tuple[str, bool]:
+    """Derive the header period string and whether the index is temporal.
+
+    Args:
+        all_df: The combined ``Data.all`` frame, or ``None`` if unavailable.
+
+    Returns:
+        A ``(period_info, temporal_index)`` tuple. ``period_info`` is empty
+        for a non-temporal (integer) index.
+
+    """
+    period_info = ""
+    temporal_index = False
+    if all_df is not None:  # pragma: no branch — Data always exposes .all; getattr default is defensive
+        date_col = all_df.columns[0]
+        temporal_index = all_df[date_col].dtype.is_temporal()
+        if temporal_index:
+            start_dt = all_df[date_col].min()
+            end_dt = all_df[date_col].max()
+            n = len(all_df)
+            period_info = f"{start_dt!s} → {end_dt!s} | {n:,} observations"
+    return period_info, temporal_index
+
+
+def _report_charts_html(plots: Any, temporal_index: bool) -> str:
+    """Render every available report chart as embedded Plotly ``<div>`` HTML.
+
+    Calendar-based charts (which resample by ``dt.year``/``dt.month``) are
+    skipped with a warning when the index is not temporal.
+
+    Args:
+        plots: The ``Data.plots`` facade, or ``None`` if unavailable.
+        temporal_index: Whether the underlying index is date/datetime typed.
+
+    Returns:
+        Concatenated chart HTML, or a placeholder when none could be rendered.
+
+    """
+    chart_parts: list[str] = []
+    if plots is not None:  # pragma: no branch — Data always exposes .plots; getattr default is defensive
+        _chart_methods: list[tuple[str, dict[str, Any]]] = [
+            ("snapshot", {}),
+            ("returns", {}),
+            ("drawdown", {}),
+            ("rolling_sharpe", {}),
+            ("rolling_volatility", {}),
+            ("monthly_heatmap", {}),
+            ("yearly_returns", {}),
+            ("histogram", {}),
+        ]
+        # These charts aggregate by calendar period (resample, dt.year/
+        # dt.month) and cannot be computed for an integer index.
+        _calendar_charts = {"snapshot", "monthly_heatmap", "yearly_returns"}
+        if not temporal_index:
+            skipped = ", ".join(m for m, _ in _chart_methods if m in _calendar_charts)
+            warnings.warn(
+                f"Index is not temporal; skipping calendar-based charts: {skipped}.",
+                stacklevel=2,
+            )
+        chart_parts = _collect_chart_divs(plots, _chart_methods, _calendar_charts, temporal_index)
+
+    return "\n".join(chart_parts) if chart_parts else "<p>No charts available.</p>"
+
+
+def _collect_chart_divs(
+    plots: Any,
+    chart_methods: list[tuple[str, dict[str, Any]]],
+    calendar_charts: set[str],
+    temporal_index: bool,
+) -> list[str]:
+    """Render each requested chart to an embedded ``<div>``, skipping the impossible.
+
+    Args:
+        plots: The ``Data.plots`` facade.
+        chart_methods: Ordered ``(method_name, kwargs)`` pairs to attempt.
+        calendar_charts: Method names that require a temporal index.
+        temporal_index: Whether the underlying index is date/datetime typed.
+
+    Returns:
+        The successfully rendered chart ``<div>`` strings, in request order.
+
+    """
+    chart_parts: list[str] = []
+    for method, kwargs in chart_methods:
+        if not temporal_index and method in calendar_charts:
+            continue
+        fn = getattr(plots, method, None)
+        if fn is None:
+            continue
+        div = _try_plotly_div(fn(**kwargs), include_cdn=not chart_parts)
+        if div:  # pragma: no branch — _try_plotly_div only returns falsy on render failure
+            chart_parts.append(f'<div style="margin-bottom:24px">{div}</div>')
+    return chart_parts

--- a/src/jquantstats/_reports/_html.py
+++ b/src/jquantstats/_reports/_html.py
@@ -188,16 +188,7 @@ def _metrics_table_html(df: pl.DataFrame) -> str:
 
     rendered: set[str] = set()
     for section_label, section_metrics in _SECTION_SPANS:
-        section_rows: list[str] = []
-        for label in section_metrics:
-            if label not in rows_by_label:
-                continue
-            vals = rows_by_label[label]
-            rendered.add(label)
-            suffix = "%" if label in _PCT_METRICS else ""
-            cells = "".join(f'<td class="metric-value">{_fmt(vals.get(a), ".2f", suffix)}</td>' for a in assets)
-            section_rows.append(f'<tr><td class="metric-name">{label}</td>{cells}</tr>\n')
-
+        section_rows = _section_rows_html(section_metrics, rows_by_label, assets, rendered)
         if section_rows:
             parts.append(
                 f'<tr class="table-section-header"><td colspan="{n_cols}"><strong>{section_label}</strong></td></tr>\n'
@@ -205,6 +196,59 @@ def _metrics_table_html(df: pl.DataFrame) -> str:
             parts.extend(section_rows)
 
     # Anything not matched by a section (e.g. string-valued rows like dates)
+    parts.extend(_unmatched_rows_html(rows_by_label, rendered, assets))
+
+    return _table_html(header_cells, "".join(parts))
+
+
+def _section_rows_html(
+    section_metrics: Any,
+    rows_by_label: dict[str, dict[str, Any]],
+    assets: list[str],
+    rendered: set[str],
+) -> list[str]:
+    """Render the ``<tr>`` rows for one metric section, in section order.
+
+    Args:
+        section_metrics: Ordered metric labels belonging to the section.
+        rows_by_label: Lookup of metric label → per-asset values.
+        assets: Asset column names, in output order.
+        rendered: Mutable set of labels already emitted; updated in place so
+            the caller can render unmatched rows afterwards.
+
+    Returns:
+        A list of HTML ``<tr>`` strings (empty when no metric matched).
+
+    """
+    section_rows: list[str] = []
+    for label in section_metrics:
+        if label not in rows_by_label:
+            continue
+        vals = rows_by_label[label]
+        rendered.add(label)
+        suffix = "%" if label in _PCT_METRICS else ""
+        cells = "".join(f'<td class="metric-value">{_fmt(vals.get(a), ".2f", suffix)}</td>' for a in assets)
+        section_rows.append(f'<tr><td class="metric-name">{label}</td>{cells}</tr>\n')
+    return section_rows
+
+
+def _unmatched_rows_html(
+    rows_by_label: dict[str, dict[str, Any]],
+    rendered: set[str],
+    assets: list[str],
+) -> list[str]:
+    """Render rows not claimed by any section (e.g. string-valued date rows).
+
+    Args:
+        rows_by_label: Lookup of metric label → per-asset values.
+        rendered: Labels already emitted by the section pass.
+        assets: Asset column names, in output order.
+
+    Returns:
+        A list of HTML ``<tr>`` strings for the leftover labels.
+
+    """
+    parts: list[str] = []
     for label, vals in rows_by_label.items():
         if label in rendered:
             continue
@@ -214,8 +258,7 @@ def _metrics_table_html(df: pl.DataFrame) -> str:
         else:
             cells = "".join(f'<td class="metric-value">{_fmt(vals.get(a), ".4f")}</td>' for a in assets)
         parts.append(f'<tr><td class="metric-name">{label}</td>{cells}</tr>\n')
-
-    return _table_html(header_cells, "".join(parts))
+    return parts
 
 
 def _drawdowns_section_html(data: Any, assets: list[str]) -> str:

--- a/src/jquantstats/_reports/_metrics.py
+++ b/src/jquantstats/_reports/_metrics.py
@@ -258,11 +258,26 @@ def _add_full_mode_rows(
     rows.append(("Best Day", _pct(_safe(s.best))))
     rows.append(("Worst Day", _pct(_safe(s.worst))))
 
-    # Benchmark greeks (only if benchmark is present). Without a benchmark,
-    # ``s.greeks()`` reaches ``benchmark_data.columns`` on a ``None`` benchmark
-    # and raises ``AttributeError``; we tolerate only that case and omit the
-    # rows. Any other error (malformed column, polars schema/arithmetic bug)
-    # propagates so genuine bugs are not silently swallowed.
+    _append_benchmark_greeks(rows, s)
+    _append_correlation(rows, data, all_df, date_col, asset_cols)
+
+    rows.append(("R²", _safe(s.r_squared)))
+    rows.append(("Treynor Ratio", _safe(s.treynor_ratio, periods=ppy)))
+
+
+def _append_benchmark_greeks(rows: list[tuple[str, dict[str, Any]]], s: Any) -> None:
+    """Append benchmark Beta/Alpha rows when a benchmark is present.
+
+    Without a benchmark, ``s.greeks()`` reaches ``benchmark_data.columns`` on a
+    ``None`` benchmark and raises ``AttributeError``; we tolerate only that case
+    and omit the rows. Any other error (malformed column, polars schema/
+    arithmetic bug) propagates so genuine bugs are not silently swallowed.
+
+    Args:
+        rows: Accumulator list of ``(label, values)`` tuples.
+        s: Stats object providing ``greeks()``.
+
+    """
     try:
         greeks = s.greeks()
         if greeks:  # pragma: no branch — greeks() raises without a benchmark, so falsy is unreachable
@@ -273,11 +288,29 @@ def _add_full_mode_rows(
     except AttributeError:
         pass
 
-    # Correlation against the benchmark. When the benchmark column is absent
-    # (no benchmark configured, or it is missing from the joined frame) polars
-    # raises ``ColumnNotFoundError`` and ``None.columns`` raises
-    # ``AttributeError`` — both mean "no benchmark to correlate against", so the
-    # row is omitted. Any other error propagates.
+
+def _append_correlation(
+    rows: list[tuple[str, dict[str, Any]]],
+    data: Any,
+    all_df: pl.DataFrame | None,
+    date_col: str | None,
+    asset_cols: list[str],
+) -> None:
+    """Append the per-asset correlation-against-benchmark row when possible.
+
+    When the benchmark column is absent (no benchmark configured, or it is
+    missing from the joined frame) polars raises ``ColumnNotFoundError`` and
+    ``None.columns`` raises ``AttributeError`` — both mean "no benchmark to
+    correlate against", so the row is omitted. Any other error propagates.
+
+    Args:
+        rows: Accumulator list of ``(label, values)`` tuples.
+        data: The DataLike object (used for benchmark access).
+        all_df: Combined DataFrame or ``None`` if unavailable.
+        date_col: Name of the date column or ``None`` if unavailable.
+        asset_cols: Asset column names.
+
+    """
     try:
         bench_obj = getattr(data, "benchmark", None)
         if bench_obj is not None and all_df is not None and date_col is not None:  # pragma: no branch
@@ -292,9 +325,6 @@ def _add_full_mode_rows(
             rows.append(("Correlation", corr_dict))
     except (AttributeError, pl.exceptions.ColumnNotFoundError):
         pass
-
-    rows.append(("R²", _safe(s.r_squared)))
-    rows.append(("Treynor Ratio", _safe(s.treynor_ratio, periods=ppy)))
 
 
 def _build_metrics_df(rows: list[tuple[str, dict[str, Any]]]) -> pl.DataFrame:

--- a/src/jquantstats/_reports/_portfolio.py
+++ b/src/jquantstats/_reports/_portfolio.py
@@ -119,26 +119,52 @@ def _stats_table_html(summary: pl.DataFrame) -> str:
         for metric in metrics:
             if metric not in metric_data:
                 continue
-            fmt, suffix = _METRIC_FORMATS.get(metric, (".4f", ""))
-            label = _METRIC_LABELS.get(metric, metric.replace("_", " ").title())
-            values = metric_data[metric]
-
-            # Find the best asset to highlight (only for higher-is-better metrics)
-            best_asset: str | None = None
-            if metric in _HIGHER_IS_BETTER:
-                finite_pairs = [(a, float(v)) for a, v in values.items() if _is_finite(v)]
-                if finite_pairs:
-                    best_asset = max(finite_pairs, key=lambda x: x[1])[0]
-
-            cells = "".join(
-                f'<td class="metric-value{"  best-value" if a == best_asset else ""}">'
-                f"{_fmt(values.get(a), fmt, suffix)}</td>"
-                for a in assets
-            )
-            rows_html_parts.append(f'<tr><td class="metric-name">{label}</td>{cells}</tr>\n')
+            rows_html_parts.append(_stats_metric_row_html(metric, metric_data[metric], assets))
 
     rows_html = "".join(rows_html_parts)
     return _table_html(header_cells, rows_html)
+
+
+def _best_asset(metric: str, values: dict[str, Any]) -> str | None:
+    """Return the asset with the highest finite value, for higher-is-better metrics.
+
+    Args:
+        metric: The metric name being rendered.
+        values: Mapping of asset name → value for this metric.
+
+    Returns:
+        The best asset name to highlight, or ``None`` when the metric is not
+        higher-is-better or has no finite values.
+
+    """
+    if metric not in _HIGHER_IS_BETTER:
+        return None
+    finite_pairs = [(a, float(v)) for a, v in values.items() if _is_finite(v)]
+    if not finite_pairs:
+        return None
+    return max(finite_pairs, key=lambda x: x[1])[0]
+
+
+def _stats_metric_row_html(metric: str, values: dict[str, Any], assets: list[str]) -> str:
+    """Render a single metric row, highlighting the best asset where applicable.
+
+    Args:
+        metric: The metric name (drives label, format, and highlight rule).
+        values: Mapping of asset name → value for this metric.
+        assets: Asset column names, in output order.
+
+    Returns:
+        An HTML ``<tr>`` string for the metric.
+
+    """
+    fmt, suffix = _METRIC_FORMATS.get(metric, (".4f", ""))
+    label = _METRIC_LABELS.get(metric, metric.replace("_", " ").title())
+    best_asset = _best_asset(metric, values)
+    cells = "".join(
+        f'<td class="metric-value{"  best-value" if a == best_asset else ""}">{_fmt(values.get(a), fmt, suffix)}</td>'
+        for a in assets
+    )
+    return f'<tr><td class="metric-name">{label}</td>{cells}</tr>\n'
 
 
 # ── Report dataclass ──────────────────────────────────────────────────────────

--- a/src/jquantstats/_stats/_reporting.py
+++ b/src/jquantstats/_stats/_reporting.py
@@ -473,49 +473,60 @@ class _ReportingStatsMixin:
         date_col_name = self._data.date_col[0] if self._data.date_col else None
         has_temporal = date_col_name is not None and all_df[date_col_name].dtype.is_temporal()
 
-        from ..data import Data
-
         if not has_temporal:
-            # Integer-index fallback: group by chunks of ~_periods_per_year rows
-            chunk = round(self._data._periods_per_year)
-            total = all_df.height
-            frames_int: list[pl.DataFrame] = []
-            for i, start in enumerate(range(0, total, chunk), start=1):
-                chunk_all = all_df.slice(start, chunk)
-                if chunk_all.height < max(5, chunk // 4):
-                    continue
-                chunk_index = chunk_all.select(self._data.date_col)
-                chunk_returns = chunk_all.select(self._data.returns.columns)
-                chunk_benchmark = (
-                    chunk_all.select(self._data.benchmark.columns) if self._data.benchmark is not None else None
-                )
-                chunk_data = Data(returns=chunk_returns, index=chunk_index, benchmark=chunk_benchmark)
-                chunk_summary = cast(Any, type(self))(chunk_data).summary()
-                chunk_summary = chunk_summary.with_columns(pl.lit(i).alias("year"))
-                frames_int.append(chunk_summary)
-            if not frames_int:
-                return pl.DataFrame()
-            result_int = pl.concat(frames_int)
-            ordered_int = ["year", "metric", *[c for c in result_int.columns if c not in ("year", "metric")]]
-            return result_int.select(ordered_int)
-
+            return self._annual_breakdown_integer(all_df)
         if date_col_name is None:  # unreachable: has_temporal guarantees non-None  # pragma: no cover
             return pl.DataFrame()  # pragma: no cover
-        years = all_df[date_col_name].dt.year().unique().sort().to_list()
+        return self._annual_breakdown_temporal(all_df, date_col_name)
 
+    def _summary_frame(self, sub_all: pl.DataFrame, index_cols: list[str], label: int) -> pl.DataFrame:
+        """Compute a `summary` for one sub-period and tag it with a ``year`` label.
+
+        Args:
+            sub_all: The combined (index + returns + benchmark) rows for the period.
+            index_cols: Column name(s) to use as the sub-period's date index.
+            label: Value written to the ``year`` column (calendar year or chunk ordinal).
+
+        Returns:
+            The summary DataFrame with an added ``year`` column.
+        """
+        from ..data import Data
+
+        sub_returns = sub_all.select(self._data.returns.columns)
+        sub_benchmark = sub_all.select(self._data.benchmark.columns) if self._data.benchmark is not None else None
+        sub_data = Data(returns=sub_returns, index=sub_all.select(index_cols), benchmark=sub_benchmark)
+        summary: pl.DataFrame = cast(Any, type(self))(sub_data).summary()
+        return summary.with_columns(pl.lit(label).alias("year"))
+
+    @staticmethod
+    def _order_breakdown(result: pl.DataFrame) -> pl.DataFrame:
+        """Reorder breakdown columns so ``year`` and ``metric`` lead."""
+        ordered = ["year", "metric", *[c for c in result.columns if c not in ("year", "metric")]]
+        return result.select(ordered)
+
+    def _annual_breakdown_integer(self, all_df: pl.DataFrame) -> pl.DataFrame:
+        """Break down by fixed row chunks (~one year each) for an integer index."""
+        chunk = round(self._data._periods_per_year)
+        total = all_df.height
+        frames: list[pl.DataFrame] = []
+        for i, start in enumerate(range(0, total, chunk), start=1):
+            chunk_all = all_df.slice(start, chunk)
+            if chunk_all.height < max(5, chunk // 4):
+                continue
+            frames.append(self._summary_frame(chunk_all, self._data.date_col, i))
+        if not frames:
+            return pl.DataFrame()
+        return self._order_breakdown(pl.concat(frames))
+
+    def _annual_breakdown_temporal(self, all_df: pl.DataFrame, date_col_name: str) -> pl.DataFrame:
+        """Break down by calendar year for a temporal index."""
+        years = all_df[date_col_name].dt.year().unique().sort().to_list()
         frames: list[pl.DataFrame] = []
         for year in years:
             year_all = all_df.filter(pl.col(date_col_name).dt.year() == year)
             if year_all.height < 2:
                 continue
-            year_index = year_all.select([date_col_name])
-            year_returns = year_all.select(self._data.returns.columns)
-            year_benchmark = year_all.select(self._data.benchmark.columns) if self._data.benchmark is not None else None
-            year_data = Data(returns=year_returns, index=year_index, benchmark=year_benchmark)
-            year_summary = cast(Any, type(self))(year_data).summary()
-            year_summary = year_summary.with_columns(pl.lit(year).alias("year"))
-            frames.append(year_summary)
-
+            frames.append(self._summary_frame(year_all, [date_col_name], year))
         if not frames:
             asset_cols = list(self._data.returns.columns)
             schema: dict[str, type[pl.DataType]] = {
@@ -524,10 +535,7 @@ class _ReportingStatsMixin:
                 **dict.fromkeys(asset_cols, pl.Float64),
             }
             return pl.DataFrame(schema=schema)
-
-        result = pl.concat(frames)
-        ordered = ["year", "metric", *[c for c in result.columns if c not in ("year", "metric")]]
-        return result.select(ordered)
+        return self._order_breakdown(pl.concat(frames))
 
     def summary(self) -> pl.DataFrame:
         """Summary statistics for each asset as a tidy DataFrame.

--- a/src/jquantstats/data.py
+++ b/src/jquantstats/data.py
@@ -184,6 +184,60 @@ def _subtract_risk_free(dframe: pl.DataFrame, rf: float | pl.DataFrame, date_col
     )
 
 
+def _require_date_col(frames: list[tuple[str, pl.DataFrame | None]], date_col: str) -> None:
+    """Verify *date_col* is present in every supplied (non-None) frame.
+
+    Args:
+        frames: ``(name, frame)`` pairs; ``None`` frames are skipped.
+        date_col: The required date column name.
+
+    Raises:
+        MissingDateColumnError: If any frame lacks *date_col*, naming that frame.
+    """
+    for frame_name, frame in frames:
+        if frame is not None and date_col not in frame.columns:
+            raise MissingDateColumnError(frame_name, column=date_col, available=list(frame.columns))
+
+
+def _align_returns_benchmark(
+    returns_pl: pl.DataFrame, benchmark_pl: pl.DataFrame, date_col: str
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Inner-join returns and benchmark on their common dates.
+
+    Args:
+        returns_pl: Returns frame with a *date_col* column.
+        benchmark_pl: Benchmark frame with a *date_col* column.
+        date_col: The shared date column name.
+
+    Returns:
+        The two frames filtered to their overlapping dates.
+
+    Raises:
+        ValueError: If the frames share no dates.
+
+    Warns:
+        BenchmarkAlignmentWarning: If aligning drops rows from either frame.
+    """
+    joined_dates = returns_pl.join(benchmark_pl, on=date_col, how="inner").select(date_col)
+    if joined_dates.is_empty():
+        raise ValueError("No overlapping dates between returns and benchmark.")  # noqa: TRY003
+    dropped_returns = returns_pl.height - joined_dates.height
+    dropped_benchmark = benchmark_pl.height - joined_dates.height
+    if dropped_returns > 0 or dropped_benchmark > 0:
+        warnings.warn(
+            f"Aligning returns and benchmark on common dates dropped "
+            f"{dropped_returns} of {returns_pl.height} returns row(s) and "
+            f"{dropped_benchmark} of {benchmark_pl.height} benchmark row(s); "
+            f"{joined_dates.height} row(s) remain. Pass a benchmark covering "
+            f"the same dates as the returns to avoid this.",
+            BenchmarkAlignmentWarning,
+            stacklevel=2,
+        )
+    returns_pl = returns_pl.join(joined_dates, on=date_col, how="inner")
+    benchmark_pl = benchmark_pl.join(joined_dates, on=date_col, how="inner")
+    return returns_pl, benchmark_pl
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class Data:
     """A container for financial returns data and an optional benchmark.
@@ -339,32 +393,12 @@ class Data:
         frames: list[tuple[str, pl.DataFrame | None]] = [("returns", returns_pl), ("benchmark", benchmark_pl)]
         if isinstance(rf_converted, pl.DataFrame):
             frames.append(("rf", rf_converted))
-        for frame_name, frame in frames:
-            if frame is not None and date_col not in frame.columns:
-                raise MissingDateColumnError(frame_name, column=date_col, available=list(frame.columns))
+        _require_date_col(frames, date_col)
 
         returns_pl = _apply_null_strategy(returns_pl, date_col, "returns", null_strategy)
         if benchmark_pl is not None:
             benchmark_pl = _apply_null_strategy(benchmark_pl, date_col, "benchmark", null_strategy)
-
-        if benchmark_pl is not None:
-            joined_dates = returns_pl.join(benchmark_pl, on=date_col, how="inner").select(date_col)
-            if joined_dates.is_empty():
-                raise ValueError("No overlapping dates between returns and benchmark.")  # noqa: TRY003
-            dropped_returns = returns_pl.height - joined_dates.height
-            dropped_benchmark = benchmark_pl.height - joined_dates.height
-            if dropped_returns > 0 or dropped_benchmark > 0:
-                warnings.warn(
-                    f"Aligning returns and benchmark on common dates dropped "
-                    f"{dropped_returns} of {returns_pl.height} returns row(s) and "
-                    f"{dropped_benchmark} of {benchmark_pl.height} benchmark row(s); "
-                    f"{joined_dates.height} row(s) remain. Pass a benchmark covering "
-                    f"the same dates as the returns to avoid this.",
-                    BenchmarkAlignmentWarning,
-                    stacklevel=2,
-                )
-            returns_pl = returns_pl.join(joined_dates, on=date_col, how="inner")
-            benchmark_pl = benchmark_pl.join(joined_dates, on=date_col, how="inner")
+            returns_pl, benchmark_pl = _align_returns_benchmark(returns_pl, benchmark_pl, date_col)
 
         index = returns_pl.select(date_col)
         excess_returns = _subtract_risk_free(returns_pl, rf_converted, date_col).drop(date_col)
@@ -692,31 +726,45 @@ class Data:
 
         """
         date_column = self.index.columns[0]
-        is_temporal = self.index[date_column].dtype.is_temporal()
 
-        if is_temporal:
-            cond = pl.lit(True)
-            if start is not None:
-                cond = cond & (pl.col(date_column) >= pl.lit(start))
-            if end is not None:
-                cond = cond & (pl.col(date_column) <= pl.lit(end))
-            mask = self.index.select(cond.alias("mask"))["mask"]
-            new_index = self.index.filter(mask)
-            new_returns = self.returns.filter(mask)
-            new_benchmark = self.benchmark.filter(mask) if self.benchmark is not None else None
+        if self.index[date_column].dtype.is_temporal():
+            new_index, new_returns, new_benchmark = self._truncate_temporal(date_column, start, end)
         else:
-            if start is not None and not isinstance(start, int):
-                raise IntegerIndexBoundError("start", type(start).__name__)
-            if end is not None and not isinstance(end, int):
-                raise IntegerIndexBoundError("end", type(end).__name__)
-            row_start = start if start is not None else 0
-            row_end = end + 1 if end is not None else self.index.height
-            length = max(0, row_end - row_start)
-            new_index = self.index.slice(row_start, length)
-            new_returns = self.returns.slice(row_start, length)
-            new_benchmark = self.benchmark.slice(row_start, length) if self.benchmark is not None else None
+            new_index, new_returns, new_benchmark = self._truncate_integer(start, end)
 
         return Data(returns=new_returns, benchmark=new_benchmark, index=new_index)
+
+    def _truncate_temporal(
+        self,
+        date_column: str,
+        start: date | datetime | str | int | None,
+        end: date | datetime | str | int | None,
+    ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame | None]:
+        """Truncate a temporal index by comparing the date column to [start, end]."""
+        cond = pl.lit(True)
+        if start is not None:
+            cond = cond & (pl.col(date_column) >= pl.lit(start))
+        if end is not None:
+            cond = cond & (pl.col(date_column) <= pl.lit(end))
+        mask = self.index.select(cond.alias("mask"))["mask"]
+        new_benchmark = self.benchmark.filter(mask) if self.benchmark is not None else None
+        return self.index.filter(mask), self.returns.filter(mask), new_benchmark
+
+    def _truncate_integer(
+        self,
+        start: date | datetime | str | int | None,
+        end: date | datetime | str | int | None,
+    ) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame | None]:
+        """Truncate an integer index by row slicing; bounds must be integers."""
+        if start is not None and not isinstance(start, int):
+            raise IntegerIndexBoundError("start", type(start).__name__)
+        if end is not None and not isinstance(end, int):
+            raise IntegerIndexBoundError("end", type(end).__name__)
+        row_start = start if start is not None else 0
+        row_end = end + 1 if end is not None else self.index.height
+        length = max(0, row_end - row_start)
+        new_benchmark = self.benchmark.slice(row_start, length) if self.benchmark is not None else None
+        return self.index.slice(row_start, length), self.returns.slice(row_start, length), new_benchmark
 
     @property
     def _periods_per_year(self) -> float:


### PR DESCRIPTION
## Summary

Fixes #863. Decomposes the ten functions ranking **radon grade C (CC 11–17)** into cohesive helpers so **no block exceeds CC 10**. Behavior-preserving refactor — no public API changes.

`radon cc src -n C` now reports **zero** C-or-worse blocks (was 10); **average CC drops 2.99 → 2.86**; every module remains maintainability-index grade A.

## Changes

| Block (original CC) | Extracted helpers |
|---|---|
| `_metrics_table_html` (17) | `_section_rows_html`, `_unmatched_rows_html` |
| `annual_breakdown` (17) | `_annual_breakdown_integer` / `_annual_breakdown_temporal`, `_summary_frame`, `_order_breakdown` |
| `Reports.full` (15) | `_report_period_info`, `_report_charts_html`, `_collect_chart_divs` |
| `_stats_table_html` (15) | `_best_asset`, `_stats_metric_row_html` |
| `_plot_performance_dashboard` (15) | `_add_cumulative_traces`, `_add_drawdown_traces`, `_add_monthly_traces` |
| `from_risk_position` (13) | `_validate_vol_cap`, `_validate_vola` |
| `from_returns` (13) | `_require_date_col`, `_align_returns_benchmark` |
| `_add_full_mode_rows` (13) | `_append_benchmark_greeks`, `_append_correlation` |
| `truncate` (12) | `_truncate_temporal`, `_truncate_integer` |
| `monthly_heatmap` (12) | `_monthly_heatmap_matrix` |

## Acceptance criterion (from #863)

- [x] `uvx radon cc src -n C` → empty (all blocks CC ≤ 10)
- [x] `make test` → 1213 passed, 5 skipped, **100.00% coverage**
- [x] `make fmt` and `make typecheck` (ty + mypy --strict) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)