### PR TITLE
docs: link changelog page from landing page (#874)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -141,4 +141,8 @@ See the [Migration Guide](MIGRATION.md) for a complete API mapping.
 
     Full method signatures and docstrings.
 
+-   :material-history: [**Changelog**](changelog.md)
+
+    Release history and notable API changes.
+
 </div>


### PR DESCRIPTION
## Summary
Closes #874.

The changelog page (`docs/changelog.md`, which renders the root `CHANGELOG.md` via `pymdownx.snippets`) already existed and was wired into the mkdocs nav (Reference → Changelog), but it was **not reachable from the docs landing page** — the only unmet part of the issue's "Done when".

This adds a **Changelog** card to the "Next Steps" grid in `docs/index.md`, matching the existing card format and using `:material-history:` (mirroring the icon in `changelog.md`'s front matter).

## Verification
- `make book` — builds clean ("No issues found").
- `_book/index.html` contains the new card linking to `changelog/`.
- `_book/changelog/index.html` renders the full changelog (version headings, sections) — confirms the snippet include still resolves.

Only `docs/index.md` (locally owned) is touched; no Rhiza-synced files, so no sync conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)